### PR TITLE
[Yosegi-19] When encoding a column, converting String to byte array is unnecessary

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/UnsafeOptimizeDumpStringColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/UnsafeOptimizeDumpStringColumnBinaryMaker.java
@@ -404,7 +404,7 @@ public class UnsafeOptimizeDumpStringColumnBinaryMaker implements IColumnBinaryM
         hasNull = true;
         continue;
       }
-      byte[] obj = strObj.getBytes( "UTF-8" );
+      byte[] obj = byteCell.getRow().getBytes();
       if ( maxLength < obj.length ) {
         maxLength = obj.length;
       }

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/UnsafeOptimizeStringColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/UnsafeOptimizeStringColumnBinaryMaker.java
@@ -567,7 +567,7 @@ public class UnsafeOptimizeStringColumnBinaryMaker implements IColumnBinaryMaker
       }
       if ( ! dicMap.containsKey( strObj ) ) {
         dicMap.put( strObj , stringList.size() );
-        byte[] obj = strObj.getBytes( "UTF-8" );
+        byte[] obj = byteCell.getRow().getBytes();
         stringList.add( obj );
         if ( maxLength < obj.length ) {
           maxLength = obj.length;


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

StringObj holds a String or byte array internally.
The current code is converted from a String to a byte array if the inside is a byte array.

With this fix, in both cases, conversion is done once.

### How did you do the test? (Not required for updating documents)

This class already has unit tests.
I confirmed that the result of the unit test does not change.