### PR TITLE
[Yosegi-21] Implement compression level optimization on bzip2.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/compressor/BZip2CommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/BZip2CommonsCompressor.java
@@ -27,6 +27,21 @@ import java.io.OutputStream;
 
 public class BZip2CommonsCompressor extends AbstractCommonsCompressor {
 
+  private int getCompressLevel( final CompressionPolicy compressionPolicy ) {
+    switch ( compressionPolicy ) {
+      case BEST_SPEED:
+        return BZip2CompressorOutputStream.MIN_BLOCKSIZE;
+      case SPEED:
+        return 3;
+      case DEFAULT:
+        return 6;
+      case BEST_COMPRESSION:
+        return BZip2CompressorOutputStream.MAX_BLOCKSIZE;
+      default:
+        return 6;
+    }
+  }
+
   @Override
   public InputStream createInputStream( final InputStream in ) throws IOException {
     return new BZip2CompressorInputStream( in );
@@ -35,7 +50,13 @@ public class BZip2CommonsCompressor extends AbstractCommonsCompressor {
   @Override
   public OutputStream createOutputStream(
       final OutputStream out , final CompressResult compressResult ) throws IOException {
-    return new BZip2CompressorOutputStream( out );
+    int level = getCompressLevel( compressResult.getCompressionPolicy() );
+    int optLevel = compressResult.getCurrentLevel();
+    if ( ( level - optLevel ) < BZip2CompressorOutputStream.MIN_BLOCKSIZE ) {
+      compressResult.setEnd();
+      optLevel = compressResult.getCurrentLevel();
+    }
+    return new BZip2CompressorOutputStream( out , level - optLevel );
   }
 
 }

--- a/src/test/java/jp/co/yahoo/yosegi/compressor/TestBZip2CommonsCompressor.java
+++ b/src/test/java/jp/co/yahoo/yosegi/compressor/TestBZip2CommonsCompressor.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.compressor;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestBZip2CommonsCompressor {
+
+  @Test
+  public void T_1() throws IOException{
+    CompressResult cr = new CompressResult( CompressionPolicy.BEST_SPEED , (double)100.0 );
+    int intCount = 1024*100;
+    byte[] t = new byte[Integer.BYTES*intCount];
+    ByteBuffer buf = ByteBuffer.wrap( t );
+    for( int i = 0 ; i < intCount ; i++ ){
+      buf.putInt( 1 );
+    }
+    BZip2CommonsCompressor compressor = new BZip2CommonsCompressor();
+    assertEquals( cr.getCurrentLevel() , 0 );
+    compressor.compress( t , 0 , t.length , cr );
+    assertEquals( cr.getCurrentLevel() , 1 );
+    compressor.compress( t , 0 , t.length , cr );
+    assertEquals( cr.getCurrentLevel() , 0 );
+     
+  }
+
+}


### PR DESCRIPTION
## What is the necessity of this update? What is updated?
I implemented the compression level control function in bzip2 compression class.

https://yosegi.atlassian.net/browse/YOSEGI-10

## How did you do the test? (Not required for updating documents)
I created a unit test and checked whether the compression level setting is less than the minimum value.