### PR TITLE
[Yosegi-23] UnsafeOptimizeDumpLongColumnBinaryMaker has incorrect calculation of byte array length.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/UnsafeOptimizeDumpLongColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/UnsafeOptimizeDumpLongColumnBinaryMaker.java
@@ -472,9 +472,9 @@ public class UnsafeOptimizeDumpLongColumnBinaryMaker implements IColumnBinaryMak
         final ByteOrder order ,
         final int rowCount ) throws IOException {
       IWriteSupporter supporter =
-          converter.toWriteSuppoter( longArray.length , buffer , start , length );
-      for ( long l : longArray ) {
-        supporter.putInt( (int)l );
+          converter.toWriteSuppoter( rowCount , buffer , start , length );
+      for ( int i = 0 ; i < rowCount ; i++ ) {
+        supporter.putInt( (int)longArray[i] );
       }
     }
 
@@ -542,7 +542,7 @@ public class UnsafeOptimizeDumpLongColumnBinaryMaker implements IColumnBinaryMak
         final ByteOrder order ,
         final int rowCount ) throws IOException {
       IWriteSupporter supporter =
-          converter.toWriteSuppoter( longArray.length , buffer , start , length );
+          converter.toWriteSuppoter( rowCount , buffer , start , length );
       for ( int i = 0 ; i < rowCount ; i++ ) {
         int castValue = (int)( longArray[i] - min );
         supporter.putInt( castValue );
@@ -613,7 +613,7 @@ public class UnsafeOptimizeDumpLongColumnBinaryMaker implements IColumnBinaryMak
         final ByteOrder order ,
         final int rowCount ) throws IOException {
       IWriteSupporter wrapBuffer =
-          converter.toWriteSuppoter( longArray.length , buffer , start , length );
+          converter.toWriteSuppoter( rowCount , buffer , start , length );
       for ( int i = 0 ; i < rowCount ; i++ ) {
         wrapBuffer.putLong( longArray[i] );
       }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Fixed bugs.
By miscalculation error of byte array, always fail under certain conditions.

### How did you do the test? (Not required for updating documents)
