### PR TITLE
fix the caluculation of row size in the getIndexIntBuffer

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/UnsafeOptimizeLongColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/UnsafeOptimizeLongColumnBinaryMaker.java
@@ -651,7 +651,14 @@ public class UnsafeOptimizeLongColumnBinaryMaker implements IColumnBinaryMaker {
         final int start ,
         final int length ,
         final ByteOrder order ) throws IOException {
-      int size = length / Integer.BYTES;
+
+      /*
+       * Althrough, getBaseBytes() of IntConverter0 returns zero,
+       * this class is not selected by the upper stream.
+       * TODO: calculation row size method may not clear, then it should be impremented.
+       */
+      int size = length / converter.getBaseBytes();
+
       IReadSupporter wrapBuffer = converter.toReadSupporter( buffer , start , length );
       IntBuffer result = IntBuffer.allocate( size );
       for ( int i = 0 ; i < size ; i++ ) {

--- a/src/main/java/jp/co/yahoo/yosegi/util/io/NumberToBinaryUtils.java
+++ b/src/main/java/jp/co/yahoo/yosegi/util/io/NumberToBinaryUtils.java
@@ -408,6 +408,8 @@ public final class NumberToBinaryUtils {
 
     int calcBinarySize( final int rows );
 
+    int getBaseBytes();
+
     IWriteSupporter toWriteSuppoter(
         final int rows ,
         final byte[] buffer ,
@@ -426,6 +428,11 @@ public final class NumberToBinaryUtils {
     @Override
     public int calcBinarySize( final int rows ) {
       return rows * Integer.BYTES + HEADER_SIZE;
+    }
+
+    @Override
+    public int getBaseBytes() {
+      return Integer.BYTES;
     }
 
     @Override
@@ -466,6 +473,11 @@ public final class NumberToBinaryUtils {
       int byteLength = Byte.BYTES * rows;
       int shortLength = Short.BYTES * rows;
       return shortLength + byteLength + HEADER_SIZE;
+    }
+
+    @Override
+    public int getBaseBytes() {
+      return Byte.BYTES + Short.BYTES;
     }
 
     @Override
@@ -530,6 +542,11 @@ public final class NumberToBinaryUtils {
     }
 
     @Override
+    public int getBaseBytes() {
+      return Short.BYTES;
+    }
+
+    @Override
     public IWriteSupporter toWriteSuppoter( final int rows , final byte[] buffer ,
         final int start , final int length ) throws IOException {
       int shortLength = Short.BYTES * rows;
@@ -579,6 +596,11 @@ public final class NumberToBinaryUtils {
     }
 
     @Override
+    public int getBaseBytes() {
+      return Byte.BYTES;
+    }
+
+    @Override
     public IWriteSupporter toWriteSuppoter( final int rows , final byte[] buffer ,
         final int start , final int length ) throws IOException {
       int byteLength = Byte.BYTES * rows;
@@ -622,6 +644,11 @@ public final class NumberToBinaryUtils {
     @Override
     public int calcBinarySize( final int rows ) {
       return HEADER_SIZE;
+    }
+
+    @Override
+    public int getBaseBytes() {
+      return 0;
     }
 
     @Override


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
fix the caluculation of row size in the getIndexIntBuffer

### How did you do the test? (Not required for updating documents)
Tested on the case that errors occurred, and confirmed that the case passed using fixed code.


