### PR TITLE
[Yosegi-33] Create Docker image to build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM centos:centos7 as java-base
+
+RUN yum -y install wget
+
+# Install OpenJDK
+RUN wget https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz
+RUN tar xvf openjdk-11_linux-x64_bin.tar.gz -C /usr/local
+
+# Install maven
+RUN curl -OL https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz
+RUN tar -xzvf apache-maven-3.6.1-bin.tar.gz
+RUN mv apache-maven-3.6.1 /opt/
+
+FROM centos:centos7
+MAINTAINER elmo
+
+ENV BUILD_WORK_DIR=$BUILD_WORK_DIR
+ENV JAVA_HOME=/usr/local/jdk-11
+ENV PATH=$PATH:/usr/local/jdk-11/bin:/opt/apache-maven-3.6.1/bin
+
+COPY --from=java-base /usr/local/jdk-11 /usr/local/jdk-11
+COPY --from=java-base /opt/apache-maven-3.6.1 /opt/apache-maven-3.6.1
+
+RUN alternatives --install /usr/bin/java java /usr/local/jdk-11/bin/java 1
+
+RUN yum install -y  git
+
+COPY build.sh /build.sh
+RUN chmod 700 /build.sh
+CMD ["/build.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN tar -xzvf apache-maven-3.6.1-bin.tar.gz
 RUN mv apache-maven-3.6.1 /opt/
 
 FROM centos:centos7
-MAINTAINER elmo
+MAINTAINER yosegi
 
 ENV BUILD_WORK_DIR=$BUILD_WORK_DIR
 ENV JAVA_HOME=/usr/local/jdk-11

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,32 @@
+<!---
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+# What is this?
+It is a docker image for building yosegi.
+
+# Create a docker image
+
+Please execute the command in this directory.
+
+```
+docker build -t yahoojp/yosegi_build_image .
+```
+
+# Run build
+
+You can set "BULD_WORK_DIR" and output the artifact.
+
+```
+mkdir /tmp/yosegi_build
+docker run -e BUILD_WORK_DIR=/tmp/yosegi_build -v /tmp/yosegi_build:/tmp/yosegi_build -it kijima/yosegi_build_image
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,5 +28,5 @@ You can set "BULD_WORK_DIR" and output the artifact.
 
 ```
 mkdir /tmp/yosegi_build
-docker run -e BUILD_WORK_DIR=/tmp/yosegi_build -v /tmp/yosegi_build:/tmp/yosegi_build -it kijima/yosegi_build_image
+docker run -e BUILD_WORK_DIR=/tmp/yosegi_build -v /tmp/yosegi_build:/tmp/yosegi_build -it yahoojp/yosegi_build_image
 ```

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+work_dir=${BUILD_WORK_DIR:-/tmp}
+
+cd $work_dir
+git clone https://github.com/yahoojapan/yosegi
+cd yosegi
+mvn clean package

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.1</version>
+        <version>3.1.0</version>
         <configuration>
           <show>package</show>
           <source>1.8</source>

--- a/src/main/java/jp/co/yahoo/yosegi/reader/YosegiSchemaFileReader.java
+++ b/src/main/java/jp/co/yahoo/yosegi/reader/YosegiSchemaFileReader.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import javax.xml.ws.WebServiceException;
 
 public class YosegiSchemaFileReader implements Closeable,IStreamReader {
 


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

I created a Docker file for building.

Fixed an error that occurs in this environment.
1. "Javax.xml.ws does not exist" occurred but it was unnecessary import
2. Update maven-javadoc-plugin version

### How did you do the test? (Not required for updating documents)

This Dockerfile has a java version of 11, but I have confirmed that it can be built in a java 8 environment.