### PR TITLE
[YOSEGI-41] Reduce memory requirements for write processing.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/BufferDirectCellManager.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/BufferDirectCellManager.java
@@ -24,6 +24,7 @@ import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.ICell;
 import jp.co.yahoo.yosegi.spread.column.ICellManager;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveCell;
+import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
 import jp.co.yahoo.yosegi.spread.column.filter.IFilter;
 import jp.co.yahoo.yosegi.spread.column.index.DefaultCellIndex;
 import jp.co.yahoo.yosegi.spread.column.index.ICellIndex;
@@ -35,6 +36,7 @@ import java.io.UncheckedIOException;
 public class BufferDirectCellManager implements ICellManager {
 
   private final ColumnType columnType;
+  private final PrimitiveColumn.ICellMaker cellMaker;
   private final IDicManager dicManager;
   private final int indexSize;
 
@@ -46,10 +48,11 @@ public class BufferDirectCellManager implements ICellManager {
   public BufferDirectCellManager(
       final ColumnType columnType ,
       final IDicManager dicManager ,
-        final int indexSize ) {
+        final int indexSize ) throws IOException {
     this.columnType = columnType;
     this.dicManager = dicManager;
     this.indexSize = indexSize;
+    cellMaker = PrimitiveColumn.getCellMaker( columnType );
   }
 
   @Override
@@ -67,7 +70,7 @@ public class BufferDirectCellManager implements ICellManager {
       if ( obj == null ) {
         return defaultCell;
       }
-      return new PrimitiveCell( columnType , dicManager.get( index ) );
+      return cellMaker.create( dicManager.get( index ) );
     } catch ( IOException ex ) {
       throw new RuntimeException( ex );
     }

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/BufferDirectDictionaryLinkCellManager.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/BufferDirectDictionaryLinkCellManager.java
@@ -24,6 +24,7 @@ import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.ICell;
 import jp.co.yahoo.yosegi.spread.column.IDictionaryCellManager;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveCell;
+import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
 import jp.co.yahoo.yosegi.spread.column.filter.IFilter;
 import jp.co.yahoo.yosegi.spread.column.filter.INullFilter;
 import jp.co.yahoo.yosegi.spread.column.index.DefaultCellIndex;
@@ -37,6 +38,7 @@ import java.nio.IntBuffer;
 public class BufferDirectDictionaryLinkCellManager implements IDictionaryCellManager {
 
   private final ColumnType columnType;
+  private final PrimitiveColumn.ICellMaker cellMaker;
   private final IDicManager dicManager;
   private final IntBuffer dicIndexIntBuffer;
   private final int indexSize;
@@ -49,10 +51,11 @@ public class BufferDirectDictionaryLinkCellManager implements IDictionaryCellMan
   public BufferDirectDictionaryLinkCellManager(
       final ColumnType columnType ,
       final IDicManager dicManager ,
-      final IntBuffer dicIndexIntBuffer ) {
+      final IntBuffer dicIndexIntBuffer ) throws IOException {
     this.columnType = columnType;
     this.dicManager = dicManager;
     this.dicIndexIntBuffer = dicIndexIntBuffer;
+    cellMaker = PrimitiveColumn.getCellMaker( columnType );
     indexSize = dicIndexIntBuffer.capacity();
   }
 
@@ -71,7 +74,7 @@ public class BufferDirectDictionaryLinkCellManager implements IDictionaryCellMan
       return defaultCell;
     }
     try {
-      return new PrimitiveCell( columnType , dicManager.get( dicIndex ) );
+      return cellMaker.create( dicManager.get( dicIndex ) );
     } catch ( IOException ex ) {
       throw new RuntimeException( ex );
     }

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/ConstantColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/ConstantColumnBinaryMaker.java
@@ -298,11 +298,14 @@ public class ConstantColumnBinaryMaker implements IColumnBinaryMaker {
      * Create a Column from a given ColumnBinary.
      */
     public ConstantCellManager(
-        final ColumnType columnType , final PrimitiveObject value , final int length ) {
+        final ColumnType columnType ,
+        final PrimitiveObject value ,
+        final int length ) throws IOException {
       this.columnType = columnType;
       this.value = value;
       this.length = length;
-      cell = new PrimitiveCell( columnType , value );
+      PrimitiveColumn.ICellMaker cellMaker = PrimitiveColumn.getCellMaker( columnType );
+      cell = cellMaker.create( value );
     }
 
     @Override

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/DumpBooleanColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/DumpBooleanColumnBinaryMaker.java
@@ -32,6 +32,7 @@ import jp.co.yahoo.yosegi.inmemory.IMemoryAllocator;
 import jp.co.yahoo.yosegi.message.objects.BooleanObj;
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 import jp.co.yahoo.yosegi.spread.analyzer.IColumnAnalizeResult;
+import jp.co.yahoo.yosegi.spread.column.BooleanCell;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.ICell;
 import jp.co.yahoo.yosegi.spread.column.ICellManager;
@@ -156,8 +157,8 @@ public class DumpBooleanColumnBinaryMaker implements IColumnBinaryMaker {
         final byte[] buffer , final PrimitiveObject trueObj , final PrimitiveObject falseObj ) {
       this.buffer = buffer;
       cellArray = new PrimitiveCell[]{
-          new PrimitiveCell( ColumnType.BOOLEAN , falseObj ) ,
-          new PrimitiveCell( ColumnType.BOOLEAN , trueObj ) , null };
+          new BooleanCell( falseObj ) ,
+          new BooleanCell( trueObj ) , null };
     }
 
     @Override

--- a/src/main/java/jp/co/yahoo/yosegi/block/IBlockWriter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/block/IBlockWriter.java
@@ -23,6 +23,7 @@ import jp.co.yahoo.yosegi.config.Configuration;
 import jp.co.yahoo.yosegi.spread.Spread;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 
 public interface IBlockWriter {
@@ -39,11 +40,11 @@ public interface IBlockWriter {
 
   int size();
 
-  byte[] createFixedBlock() throws IOException;
+  void writeFixedBlock( final OutputStream out ) throws IOException;
 
-  byte[] createVariableBlock() throws IOException;
+  void writeVariableBlock( final OutputStream out ) throws IOException;
 
-  byte[] create( final int dataSize ) throws IOException;
+  void write( final OutputStream out , final int dataSize ) throws IOException;
 
   String getReaderClassName();
 

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowBooleanConnector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowBooleanConnector.java
@@ -58,7 +58,7 @@ public class ArrowBooleanConnector implements IArrowPrimitiveConnector {
     if ( vector.isNull( index ) ) {
       return defaultCell;
     }
-    return new PrimitiveCell( ColumnType.BOOLEAN , new BooleanObj( vector.get( index ) == 1 ) );
+    return new BooleanCell( new BooleanObj( vector.get( index ) == 1 ) );
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowByteConnector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowByteConnector.java
@@ -59,7 +59,7 @@ public class ArrowByteConnector implements IArrowPrimitiveConnector {
     if ( vector.isNull( index ) ) {
       return defaultCell;
     }
-    return new PrimitiveCell( ColumnType.BYTE , new ByteObj( vector.get( index ) ) );
+    return new ByteCell( new ByteObj( vector.get( index ) ) );
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowBytesConnector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowBytesConnector.java
@@ -59,7 +59,7 @@ public class ArrowBytesConnector implements IArrowPrimitiveConnector {
     if ( vector.isNull( index ) ) {
       return defaultCell;
     }
-    return new PrimitiveCell( ColumnType.BYTES , new BytesObj( vector.get( index ) ) );
+    return new BytesCell( new BytesObj( vector.get( index ) ) );
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowDoubleConnector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowDoubleConnector.java
@@ -58,7 +58,7 @@ public class ArrowDoubleConnector implements IArrowPrimitiveConnector {
     if ( vector.isNull( index ) ) {
       return defaultCell;
     }
-    return new PrimitiveCell( ColumnType.DOUBLE , new DoubleObj( vector.get( index ) ) );
+    return new DoubleCell( new DoubleObj( vector.get( index ) ) );
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowFloatConnector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowFloatConnector.java
@@ -58,7 +58,7 @@ public class ArrowFloatConnector implements IArrowPrimitiveConnector {
     if ( vector.isNull( index ) ) {
       return defaultCell;
     }
-    return new PrimitiveCell( ColumnType.FLOAT , new FloatObj( vector.get( index ) ) );
+    return new FloatCell( new FloatObj( vector.get( index ) ) );
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowIntegerConnector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowIntegerConnector.java
@@ -58,7 +58,7 @@ public class ArrowIntegerConnector implements IArrowPrimitiveConnector {
     if ( vector.isNull( index ) ) {
       return defaultCell;
     }
-    return new PrimitiveCell( ColumnType.INTEGER , new IntegerObj( vector.get( index ) ) );
+    return new IntegerCell( new IntegerObj( vector.get( index ) ) );
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowLongConnector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowLongConnector.java
@@ -59,7 +59,7 @@ public class ArrowLongConnector implements IArrowPrimitiveConnector {
     if ( vector.isNull( index ) ) {
       return defaultCell;
     }
-    return new PrimitiveCell( ColumnType.LONG , new LongObj( vector.get( index ) ) );
+    return new LongCell( new LongObj( vector.get( index ) ) );
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowShortConnector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowShortConnector.java
@@ -58,7 +58,7 @@ public class ArrowShortConnector implements IArrowPrimitiveConnector {
     if ( vector.isNull( index ) ) {
       return defaultCell;
     }
-    return new PrimitiveCell( ColumnType.SHORT , new ShortObj( vector.get( index ) ) );
+    return new ShortCell( new ShortObj( vector.get( index ) ) );
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowStringConnector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrowStringConnector.java
@@ -58,7 +58,7 @@ public class ArrowStringConnector implements IArrowPrimitiveConnector {
     if ( vector.isNull( index ) ) {
       return defaultCell;
     }
-    return new PrimitiveCell( ColumnType.STRING , new BytesStringObj( vector.get( index ) ) );
+    return new StringCell( new BytesStringObj( vector.get( index ) ) );
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/BooleanCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/BooleanCell.java
@@ -16,14 +16,21 @@
  * limitations under the License.
  */
 
-package jp.co.yahoo.yosegi.constants;
+package jp.co.yahoo.yosegi.spread.column;
 
-public final class PrimitiveByteLength {
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
-  // PrimitiveCell + PrimitiveObject
-  public static final int JAVA_OBJECT_LENGTH = 16 + 16;
-  public static final int BOOLEAN_LENGTH = 1;
+import java.io.IOException;
 
-  private PrimitiveByteLength(){}
+public class BooleanCell extends PrimitiveCell {
+
+  public BooleanCell( final PrimitiveObject raw ) {
+    super( raw );
+  }
+
+  @Override
+  public ColumnType getType() {
+    return ColumnType.BOOLEAN;
+  }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ByteCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ByteCell.java
@@ -16,14 +16,21 @@
  * limitations under the License.
  */
 
-package jp.co.yahoo.yosegi.constants;
+package jp.co.yahoo.yosegi.spread.column;
 
-public final class PrimitiveByteLength {
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
-  // PrimitiveCell + PrimitiveObject
-  public static final int JAVA_OBJECT_LENGTH = 16 + 16;
-  public static final int BOOLEAN_LENGTH = 1;
+import java.io.IOException;
 
-  private PrimitiveByteLength(){}
+public class ByteCell extends PrimitiveCell {
+
+  public ByteCell( final PrimitiveObject raw ) {
+    super( raw );
+  }
+
+  @Override
+  public ColumnType getType() {
+    return ColumnType.BYTE;
+  }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/BytesCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/BytesCell.java
@@ -16,14 +16,21 @@
  * limitations under the License.
  */
 
-package jp.co.yahoo.yosegi.constants;
+package jp.co.yahoo.yosegi.spread.column;
 
-public final class PrimitiveByteLength {
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
-  // PrimitiveCell + PrimitiveObject
-  public static final int JAVA_OBJECT_LENGTH = 16 + 16;
-  public static final int BOOLEAN_LENGTH = 1;
+import java.io.IOException;
 
-  private PrimitiveByteLength(){}
+public class BytesCell extends PrimitiveCell {
+
+  public BytesCell( final PrimitiveObject raw ) {
+    super( raw );
+  }
+
+  @Override
+  public ColumnType getType() {
+    return ColumnType.BYTES;
+  }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/DoubleCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/DoubleCell.java
@@ -16,14 +16,21 @@
  * limitations under the License.
  */
 
-package jp.co.yahoo.yosegi.constants;
+package jp.co.yahoo.yosegi.spread.column;
 
-public final class PrimitiveByteLength {
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
-  // PrimitiveCell + PrimitiveObject
-  public static final int JAVA_OBJECT_LENGTH = 16 + 16;
-  public static final int BOOLEAN_LENGTH = 1;
+import java.io.IOException;
 
-  private PrimitiveByteLength(){}
+public class DoubleCell extends PrimitiveCell {
+
+  public DoubleCell( final PrimitiveObject raw ) {
+    super( raw );
+  }
+
+  @Override
+  public ColumnType getType() {
+    return ColumnType.DOUBLE;
+  }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/FloatCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/FloatCell.java
@@ -16,14 +16,21 @@
  * limitations under the License.
  */
 
-package jp.co.yahoo.yosegi.constants;
+package jp.co.yahoo.yosegi.spread.column;
 
-public final class PrimitiveByteLength {
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
-  // PrimitiveCell + PrimitiveObject
-  public static final int JAVA_OBJECT_LENGTH = 16 + 16;
-  public static final int BOOLEAN_LENGTH = 1;
+import java.io.IOException;
 
-  private PrimitiveByteLength(){}
+public class FloatCell extends PrimitiveCell {
+
+  public FloatCell( final PrimitiveObject raw ) {
+    super( raw );
+  }
+
+  @Override
+  public ColumnType getType() {
+    return ColumnType.FLOAT;
+  }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/IntegerCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/IntegerCell.java
@@ -16,14 +16,21 @@
  * limitations under the License.
  */
 
-package jp.co.yahoo.yosegi.constants;
+package jp.co.yahoo.yosegi.spread.column;
 
-public final class PrimitiveByteLength {
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
-  // PrimitiveCell + PrimitiveObject
-  public static final int JAVA_OBJECT_LENGTH = 16 + 16;
-  public static final int BOOLEAN_LENGTH = 1;
+import java.io.IOException;
 
-  private PrimitiveByteLength(){}
+public class IntegerCell extends PrimitiveCell {
+
+  public IntegerCell( final PrimitiveObject raw ) {
+    super( raw );
+  }
+
+  @Override
+  public ColumnType getType() {
+    return ColumnType.INTEGER;
+  }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/LongCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/LongCell.java
@@ -16,14 +16,21 @@
  * limitations under the License.
  */
 
-package jp.co.yahoo.yosegi.constants;
+package jp.co.yahoo.yosegi.spread.column;
 
-public final class PrimitiveByteLength {
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
-  // PrimitiveCell + PrimitiveObject
-  public static final int JAVA_OBJECT_LENGTH = 16 + 16;
-  public static final int BOOLEAN_LENGTH = 1;
+import java.io.IOException;
 
-  private PrimitiveByteLength(){}
+public class LongCell extends PrimitiveCell {
+
+  public LongCell( final PrimitiveObject raw ) {
+    super( raw );
+  }
+
+  @Override
+  public ColumnType getType() {
+    return ColumnType.LONG;
+  }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/PrimitiveCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/PrimitiveCell.java
@@ -22,24 +22,17 @@ import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
 import java.io.IOException;
 
-public class PrimitiveCell implements ICell<PrimitiveObject,PrimitiveObject> {
+public abstract class PrimitiveCell implements ICell<PrimitiveObject,PrimitiveObject> {
 
-  private final ColumnType columnType;
   private PrimitiveObject raw;
 
-  public PrimitiveCell( final ColumnType columnType , final PrimitiveObject raw ) {
+  public PrimitiveCell( final PrimitiveObject raw ) {
     this.raw = raw;
-    this.columnType = columnType;
   }
 
   @Override
   public PrimitiveObject getRow() {
     return raw;
-  }
-
-  @Override
-  public ColumnType getType() {
-    return columnType;
   }
 
   @Override

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/PrimitiveColumn.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/PrimitiveColumn.java
@@ -32,7 +32,85 @@ import java.util.stream.IntStream;
 
 public class PrimitiveColumn implements IColumn {
 
+  public interface ICellMaker {
+    PrimitiveCell create( final PrimitiveObject obj );
+  }
+
+  /**
+   * Create cell maker.
+   */
+  public static ICellMaker getCellMaker( final ColumnType columnType ) throws IOException {
+    switch ( columnType ) {
+      case BOOLEAN:
+        return new ICellMaker() {
+          @Override
+          public PrimitiveCell create( final PrimitiveObject obj ) {
+            return new StringCell( obj );
+          }
+        };
+      case BYTE:
+        return new ICellMaker() {
+          @Override
+          public PrimitiveCell create( final PrimitiveObject obj ) {
+            return new ByteCell( obj );
+          }
+        };
+      case BYTES:
+        return new ICellMaker() {
+          @Override
+          public PrimitiveCell create( final PrimitiveObject obj ) {
+            return new BytesCell( obj );
+          }
+        };
+      case DOUBLE:
+        return new ICellMaker() {
+          @Override
+          public PrimitiveCell create( final PrimitiveObject obj ) {
+            return new DoubleCell( obj );
+          }
+        };
+      case FLOAT:
+        return new ICellMaker() {
+          @Override
+          public PrimitiveCell create( final PrimitiveObject obj ) {
+            return new FloatCell( obj );
+          }
+        };
+      case INTEGER:
+        return new ICellMaker() {
+          @Override
+          public PrimitiveCell create( final PrimitiveObject obj ) {
+            return new IntegerCell( obj );
+          }
+        };
+      case LONG:
+        return new ICellMaker() {
+          @Override
+          public PrimitiveCell create( final PrimitiveObject obj ) {
+            return new LongCell( obj );
+          }
+        };
+      case SHORT:
+        return new ICellMaker() {
+          @Override
+          public PrimitiveCell create( final PrimitiveObject obj ) {
+            return new ShortCell( obj );
+          }
+        };
+      case STRING:
+        return new ICellMaker() {
+          @Override
+          public PrimitiveCell create( final PrimitiveObject obj ) {
+            return new StringCell( obj );
+          }
+        };
+      default:
+        throw new IOException( "Unknown column type : " + columnType.toString() );
+    }
+  }
+
   private final ColumnType columnType;
+  private final ICellMaker cellMaker;
   private String columnName;
   private ICellManager cellManager;
   private IColumn parentsColumn = NullColumn.getInstance();
@@ -41,9 +119,11 @@ public class PrimitiveColumn implements IColumn {
   /**
    * Initialized by setting Primitive type and column name.
    */
-  public PrimitiveColumn( final ColumnType columnType , final String columnName ) {
+  public PrimitiveColumn(
+      final ColumnType columnType , final String columnName ) throws IOException {
     this.columnType = columnType;
     this.columnName = columnName;
+    cellMaker = getCellMaker( columnType );
     cellManager = new CellManager();
   }
 
@@ -77,7 +157,7 @@ public class PrimitiveColumn implements IColumn {
     if ( type != getColumnType() ) {
       throw new IOException( "Incorrect input data type : " + obj.getClass().getName() );
     }
-    cellManager.add( new PrimitiveCell( columnType , (PrimitiveObject)obj ) , index );
+    cellManager.add( cellMaker.create( (PrimitiveObject)obj ) , index );
     return ColumnTypeFactory.getColumnTypeToJavaPrimitiveByteSize(
         columnType , (PrimitiveObject)obj );
   }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ShortCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ShortCell.java
@@ -16,14 +16,21 @@
  * limitations under the License.
  */
 
-package jp.co.yahoo.yosegi.constants;
+package jp.co.yahoo.yosegi.spread.column;
 
-public final class PrimitiveByteLength {
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
-  // PrimitiveCell + PrimitiveObject
-  public static final int JAVA_OBJECT_LENGTH = 16 + 16;
-  public static final int BOOLEAN_LENGTH = 1;
+import java.io.IOException;
 
-  private PrimitiveByteLength(){}
+public class ShortCell extends PrimitiveCell {
+
+  public ShortCell( final PrimitiveObject raw ) {
+    super( raw );
+  }
+
+  @Override
+  public ColumnType getType() {
+    return ColumnType.SHORT;
+  }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/StringCell.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/StringCell.java
@@ -16,14 +16,21 @@
  * limitations under the License.
  */
 
-package jp.co.yahoo.yosegi.constants;
+package jp.co.yahoo.yosegi.spread.column;
 
-public final class PrimitiveByteLength {
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
-  // PrimitiveCell + PrimitiveObject
-  public static final int JAVA_OBJECT_LENGTH = 16 + 16;
-  public static final int BOOLEAN_LENGTH = 1;
+import java.io.IOException;
 
-  private PrimitiveByteLength(){}
+public class StringCell extends PrimitiveCell {
+
+  public StringCell( final PrimitiveObject raw ) {
+    super( raw );
+  }
+
+  @Override
+  public ColumnType getType() {
+    return ColumnType.STRING;
+  }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/writer/YosegiRecordWriter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/writer/YosegiRecordWriter.java
@@ -18,12 +18,14 @@
 
 package jp.co.yahoo.yosegi.writer;
 
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.config.Configuration;
 import jp.co.yahoo.yosegi.message.parser.IParser;
 import jp.co.yahoo.yosegi.spread.Spread;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.Map;
 
 public class YosegiRecordWriter implements AutoCloseable {
@@ -81,8 +83,10 @@ public class YosegiRecordWriter implements AutoCloseable {
 
   private void flushSpread() throws IOException {
     if ( spreadSize < currentDataSize || maxRows <= currentRows ) {
-      fileWriter.append( currentSpread );
+      List<ColumnBinary> columnBinary = fileWriter.convertRow( currentSpread );
       currentSpread = new Spread();
+      fileWriter.appendRow( columnBinary , currentRows );
+
       currentDataSize = 0;
       currentRows = 0;
     }

--- a/src/main/java/jp/co/yahoo/yosegi/writer/YosegiWriter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/writer/YosegiWriter.java
@@ -69,6 +69,13 @@ public class YosegiWriter implements AutoCloseable {
   }
 
   /**
+   * Convert Spread to ColumnBinary.
+   */
+  public List<ColumnBinary> convertRow( final Spread spread ) throws IOException {
+    return blockMaker.convertRow( spread );
+  }
+
+  /**
    * Add Spread as a Spread.
    */
   public void append( final Spread spread ) throws IOException {
@@ -82,8 +89,7 @@ public class YosegiWriter implements AutoCloseable {
   public void appendRow(
       final List<ColumnBinary> binaryList, final int spreadSize ) throws IOException {
     if ( ! blockMaker.canAppend( binaryList ) ) {
-      byte[] block = blockMaker.createFixedBlock();
-      out.write( block , 0 , block.length );
+      blockMaker.writeFixedBlock( out );
     }
     blockMaker.append( spreadSize , binaryList );
   }
@@ -92,8 +98,7 @@ public class YosegiWriter implements AutoCloseable {
    * Close.
    */
   public void close() throws IOException {
-    byte[] block = blockMaker.createVariableBlock();
-    out.write( block , 0 , block.length );
+    blockMaker.writeVariableBlock( out );
     blockMaker.close();
     out.close();
   }

--- a/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestLazyColumn.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestLazyColumn.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveCell;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
+import jp.co.yahoo.yosegi.spread.column.StringCell;
 
 import jp.co.yahoo.yosegi.message.objects.*;
 
@@ -96,7 +97,7 @@ public class TestLazyColumn {
   @Test
   public void T_addCell_1()throws IOException{
     LazyColumn column = new LazyColumn( "dummy" , ColumnType.STRING , new TestColumnMnager() );
-    column.addCell( ColumnType.STRING ,  new PrimitiveCell( ColumnType.STRING , null ) , 3 );
+    column.addCell( ColumnType.STRING ,  new StringCell( null ) , 3 );
   }
 
   @Test

--- a/src/test/java/jp/co/yahoo/yosegi/spread/column/TestBooleanCell.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/column/TestBooleanCell.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.spread.column;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestBooleanCell {
+
+  @Test
+  public void T_getType() {
+    assertEquals( new BooleanCell( null ).getType(), ColumnType.BOOLEAN );
+  }
+
+}

--- a/src/test/java/jp/co/yahoo/yosegi/spread/column/TestByteCell.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/column/TestByteCell.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.spread.column;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestByteCell {
+
+  @Test
+  public void T_getType() {
+    assertEquals( new ByteCell( null ).getType(), ColumnType.BYTE );
+  }
+
+}

--- a/src/test/java/jp/co/yahoo/yosegi/spread/column/TestBytesCell.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/column/TestBytesCell.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.spread.column;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestBytesCell {
+
+  @Test
+  public void T_getType() {
+    assertEquals( new BytesCell( null ).getType(), ColumnType.BYTES );
+  }
+
+}

--- a/src/test/java/jp/co/yahoo/yosegi/spread/column/TestDoubleCell.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/column/TestDoubleCell.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.spread.column;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestDoubleCell {
+
+  @Test
+  public void T_getType() {
+    assertEquals( new DoubleCell( null ).getType(), ColumnType.DOUBLE );
+  }
+
+}

--- a/src/test/java/jp/co/yahoo/yosegi/spread/column/TestFloatCell.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/column/TestFloatCell.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.spread.column;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestFloatCell {
+
+  @Test
+  public void T_getType() {
+    assertEquals( new FloatCell( null ).getType(), ColumnType.FLOAT );
+  }
+
+}

--- a/src/test/java/jp/co/yahoo/yosegi/spread/column/TestIntegerCell.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/column/TestIntegerCell.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.spread.column;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestIntegerCell {
+
+  @Test
+  public void T_getType() {
+    assertEquals( new IntegerCell( null ).getType(), ColumnType.INTEGER );
+  }
+
+}

--- a/src/test/java/jp/co/yahoo/yosegi/spread/column/TestLongCell.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/column/TestLongCell.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.spread.column;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestLongCell {
+
+  @Test
+  public void T_getType() {
+    assertEquals( new LongCell( null ).getType(), ColumnType.LONG );
+  }
+
+}

--- a/src/test/java/jp/co/yahoo/yosegi/spread/column/TestShortCell.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/column/TestShortCell.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.spread.column;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestShortCell {
+
+  @Test
+  public void T_getType() {
+    assertEquals( new ShortCell( null ).getType(), ColumnType.SHORT );
+  }
+
+}

--- a/src/test/java/jp/co/yahoo/yosegi/spread/column/TestStringCell.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/column/TestStringCell.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.spread.column;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class TestStringCell {
+
+  @Test
+  public void T_getType() {
+    assertEquals( new StringCell( null ).getType(), ColumnType.STRING );
+  }
+
+}


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
1.
Changed Java object from 8 bytes to 32 bytes of PrimitiveObject (16 bytes) + PrimitiveCell (16 bytes) in the calculation of memory for the writing process.
2.
The object size of PrimitiveCell was 24 bytes.
Since the reference of ColumnType was 8 bytes, I made it not to have ColumnType in Cell object.
3.
BlockMaker created a byte array of blocks but modified it to write to the OutputStream given as an argument.

### How did you do the test? (Not required for updating documents)
Verify that all unit tests are correct