### PR TITLE
[Yosegi-43] Default block size is too large.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/writer/YosegiWriter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/writer/YosegiWriter.java
@@ -44,7 +44,7 @@ public class YosegiWriter implements AutoCloseable {
   public YosegiWriter( final OutputStream out , final Configuration config ) throws IOException {
     this.out = out;
 
-    int blockSize = config.getInt( "block.size" , 1024 * 1024 * 128 );
+    int blockSize = config.getInt( "block.size" , 1024 * 1024 * 64 );
 
     blockMaker = FindBlockWriter.get(
         config.get( "block.maker.class" , PushdownSupportedBlockWriter.class.getName() ) );


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
The default 128 MB is too big, so I think you should reduce it to 64 MB by half.

### How did you do the test? (Not required for updating documents)
