### PR TITLE
Yosegi-41 Delete data buffer at block creation.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/block/ColumnBinaryTree.java
+++ b/src/main/java/jp/co/yahoo/yosegi/block/ColumnBinaryTree.java
@@ -24,6 +24,7 @@ import jp.co.yahoo.yosegi.spread.column.ColumnTypeFactory;
 import jp.co.yahoo.yosegi.util.ByteArrayData;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,6 +36,7 @@ public class ColumnBinaryTree {
 
   private final List<ColumnBinary> currentColumnBinaryList = new ArrayList<ColumnBinary>();
   private final Map<String,ColumnBinaryTree> childTreeMap = new HashMap<String,ColumnBinaryTree>();
+  private final List<String> childKeyList = new ArrayList();
   private final List<BlockReadOffset> blockReadOffsetList = new ArrayList<BlockReadOffset>();
 
   private ColumnNameNode columnNameNode;
@@ -95,6 +97,7 @@ public class ColumnBinaryTree {
             childTree.add( null );
           }
           childTreeMap.put( childColumnBinary.columnName , childTree );
+          childKeyList.add( childColumnBinary.columnName );
         }
         childTree.add( childColumnBinary );
       }
@@ -189,6 +192,7 @@ public class ColumnBinaryTree {
       }
       if ( isAppend ) {
         childTreeMap.put( childName , childColumnBinary );
+        childKeyList.add( childName );
       }
     }
     allBinaryStart = byteBuffer.getInt( offset );
@@ -258,8 +262,9 @@ public class ColumnBinaryTree {
    * Convert the column data held by this object into a byte array
    * and assign it to the byte buffer of the argument.
    */
-  public void create(
-      final ByteArrayData metaBuffer , final ByteArrayData buffer ) throws IOException {
+  public int createMeta(
+      final ByteArrayData metaBuffer , final int dataStartOffset ) throws IOException {
+    int binaryOffset = dataStartOffset;
     byte[] binaryOffsetMetaData = new byte[Integer.BYTES * 3];
     if ( ! currentColumnBinaryList.isEmpty() ) {
       byte[] currentMetaBinary =
@@ -267,7 +272,7 @@ public class ColumnBinaryTree {
       ByteBuffer wrapMetaBinaryBuffer = ByteBuffer.wrap( currentMetaBinary );
       int currentMetaBinaryOffset = 0;
 
-      allBinaryStart = buffer.getLength();
+      allBinaryStart = binaryOffset;
       for ( int i = 0 ; i < currentColumnBinaryList.size() ; i++ ) {
         ColumnBinary columnBinary = currentColumnBinaryList.get(i);
         wrapMetaBinaryBuffer.putInt( currentMetaBinaryOffset , i );
@@ -276,13 +281,12 @@ public class ColumnBinaryTree {
           wrapMetaBinaryBuffer.putInt( currentMetaBinaryOffset , 0 );
           currentMetaBinaryOffset += Integer.BYTES;
         } else {
-          int binaryStart = buffer.getLength();
-          buffer.append(
-              columnBinary.binary , columnBinary.binaryStart , columnBinary.binaryLength );
-          int binaryLength = buffer.getLength() - binaryStart;
+          int binaryStart = binaryOffset;
+          binaryOffset += columnBinary.binaryLength;
+          int originalBinaryStart = columnBinary.binaryStart;
           columnBinary.binaryStart = binaryStart;
-          columnBinary.binaryLength = binaryLength;
           byte[] metaBinary = columnBinary.toMetaBinary();
+          columnBinary.binaryStart = originalBinaryStart;
           byte[] lengthMetaBinary = new byte[ Integer.BYTES + metaBinary.length ];
           ByteBuffer metaWrapBuffer = ByteBuffer.wrap( lengthMetaBinary );
           metaWrapBuffer.putInt( metaBinary.length );
@@ -296,7 +300,7 @@ public class ColumnBinaryTree {
           currentMetaBinaryOffset += lengthMetaBinary.length;
         }
       }
-      allBinaryLength = buffer.getLength() - allBinaryStart;
+      allBinaryLength = binaryOffset - allBinaryStart;
       binaryOffsetMetaData = new byte[ Integer.BYTES * 3 + currentMetaBinary.length ];
       ByteBuffer wrapBuffer = ByteBuffer.wrap( binaryOffsetMetaData );
       wrapBuffer.putInt( allBinaryStart );
@@ -316,17 +320,41 @@ public class ColumnBinaryTree {
     wrapBuffer.putInt( 0 , childSize );
     metaBuffer.append( childSizeBytes );
 
-    for ( Map.Entry<String,ColumnBinaryTree> entry : childTreeMap.entrySet() ) {
-      byte[] childNameBytes = entry.getKey().getBytes( "UTF-8" );
+    for ( String columnName : childKeyList ) {
+      byte[] childNameBytes = columnName.getBytes( "UTF-8" );
       byte[] lengthBytes = new byte[ Integer.BYTES + childNameBytes.length ];
       ByteBuffer childWrapBuffer = ByteBuffer.wrap( lengthBytes );
       childWrapBuffer.putInt( childNameBytes.length );
       childWrapBuffer.put( childNameBytes );
       metaBuffer.append( lengthBytes );
-      entry.getValue().create( metaBuffer , buffer );
+      ColumnBinaryTree childTree = childTreeMap.get( columnName );
+      binaryOffset = childTree.createMeta( metaBuffer , binaryOffset );
     }
 
     metaBuffer.append( binaryOffsetMetaData );
+    return binaryOffset;
+  }
+
+  /**
+   * Write data.
+   */
+  public int writeData( final OutputStream out ) throws IOException {
+    int writeDataSize = 0;
+    if ( ! currentColumnBinaryList.isEmpty() ) {
+      for ( int i = 0 ; i < currentColumnBinaryList.size() ; i++ ) {
+        ColumnBinary columnBinary = currentColumnBinaryList.get(i);
+        if ( columnBinary != null ) {
+          out.write(
+              columnBinary.binary , columnBinary.binaryStart , columnBinary.binaryLength );
+          writeDataSize += columnBinary.binaryLength;
+        }
+      }
+    }
+    for ( String columnName : childKeyList ) {
+      ColumnBinaryTree childTree = childTreeMap.get( columnName );
+      writeDataSize += childTree.writeData( out );
+    }
+    return writeDataSize;
   }
 
   /**
@@ -338,12 +366,12 @@ public class ColumnBinaryTree {
     }
     currentColumnBinaryList.clear();
     childTreeMap.clear();
+    childKeyList.clear();
     columnNameNode = null;
     blockReadOffsetList.clear();
     currentCount = 0;
     childCount = 0;
     metaLength = 0;
-    childCount = 0;
     allBinaryLength = 0;
   }
 


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Removed ByteArrayData which is a buffer of data.
This fix reduces the heap size of the block size.

### How did you do the test? (Not required for updating documents)
Removed ByteArrayData which is a buffer of data.
This fix reduces the heap size of the block size.
