### PR TITLE
Yosegi-57 Buffer overflow.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/binary/ColumnBinary.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/ColumnBinary.java
@@ -81,12 +81,12 @@ public class ColumnBinary {
   /**
    * Calculate the converted binary size of this object.
    */
-  public int size() throws IOException {
+  public int binarySize() throws IOException {
     int length = binaryLength;
 
     if ( columnBinaryList != null ) {
       for ( ColumnBinary child : columnBinaryList ) {
-        length += child.size();
+        length += child.binarySize();
       }
     }
     return length;

--- a/src/main/java/jp/co/yahoo/yosegi/binary/ColumnBinary.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/ColumnBinary.java
@@ -82,21 +82,7 @@ public class ColumnBinary {
    * Calculate the converted binary size of this object.
    */
   public int size() throws IOException {
-    int length =
-        ( makerClassName.length() * Character.BYTES )
-        + Integer.BYTES
-        + ( compressorClassName.length() * Character.BYTES )
-        + Integer.BYTES
-        + ( columnName.length() * Character.BYTES )
-        + Integer.BYTES
-        + Byte.BYTES
-        + Integer.BYTES
-        + Integer.BYTES
-        + Integer.BYTES
-        + Integer.BYTES
-        + Integer.BYTES
-        + Integer.BYTES
-        + binaryLength;
+    int length = binaryLength;
 
     if ( columnBinaryList != null ) {
       for ( ColumnBinary child : columnBinaryList ) {

--- a/src/main/java/jp/co/yahoo/yosegi/block/ColumnBinaryTree.java
+++ b/src/main/java/jp/co/yahoo/yosegi/block/ColumnBinaryTree.java
@@ -445,7 +445,7 @@ public class ColumnBinaryTree {
   public int dataSizeAfterAppend( final List<ColumnBinary> rootBinaryList ) throws IOException {
     int result = dataSize();
     for ( ColumnBinary binary : rootBinaryList ) {
-      result += binary.size();
+      result += binary.binarySize();
     }
     return result;
   }

--- a/src/main/java/jp/co/yahoo/yosegi/block/ColumnBinaryTree.java
+++ b/src/main/java/jp/co/yahoo/yosegi/block/ColumnBinaryTree.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +44,7 @@ public class ColumnBinaryTree {
   private int currentCount;
   private int childCount;
   private int metaLength;
+  private int dataSize;
   private int allBinaryStart;
   private int allBinaryLength;
 
@@ -79,6 +81,7 @@ public class ColumnBinaryTree {
       addChild( null );
     } else {
       metaLength += columnBinary.getMetaSize();
+      dataSize += columnBinary.binaryLength;
       addChild( columnBinary.columnBinaryList );
     }
   }
@@ -336,6 +339,129 @@ public class ColumnBinaryTree {
   }
 
   /**
+   * Get current metadata size.
+   */
+  public int metaSize() throws IOException {
+    int result = 0;
+    result += Integer.BYTES;
+    result += Integer.BYTES * 3;
+    result += ( Integer.BYTES * 2 ) * currentColumnBinaryList.size();
+    result += metaLength;
+
+    for ( Map.Entry<String,ColumnBinaryTree> entry : childTreeMap.entrySet() ) {
+      result += entry.getValue().metaSize();
+    }
+
+    for ( String columnName : childKeyList ) {
+      byte[] childNameBytes = columnName.getBytes( "UTF-8" );
+      result += Integer.BYTES + childNameBytes.length;
+    }
+    return result;
+  }
+
+  private int metaSizeAfterAppend( final ColumnBinary columnBinary ) throws IOException {
+    int result = 0;
+    result += Integer.BYTES;
+    result += Integer.BYTES * 3;
+    result += ( Integer.BYTES * 2 ) * ( currentColumnBinaryList.size() + 1 );
+    result += metaLength;
+
+    Set<String> childKeySet = new HashSet<String>();
+    if ( columnBinary != null ) {
+      result += columnBinary.getMetaSize();
+      if ( columnBinary.columnBinaryList != null ) {
+        for ( ColumnBinary childColumnBinary : columnBinary.columnBinaryList ) {
+          ColumnBinaryTree childTree = childTreeMap.get( childColumnBinary.columnName );
+          if ( childTree == null ) {
+            byte[] childNameBytes = childColumnBinary.columnName.getBytes( "UTF-8" );
+            result += Integer.BYTES + childNameBytes.length;
+            childTree = new ColumnBinaryTree();
+            while ( childTree.size() < ( getChildSize() ) ) {
+              childTree.add( null );
+            }
+          }
+          result += childTree.metaSizeAfterAppend( childColumnBinary );
+          childKeySet.add( childColumnBinary.columnName );
+        }
+      }
+    }
+
+    for ( Map.Entry<String,ColumnBinaryTree> entry : childTreeMap.entrySet() ) {
+      if ( ! childKeySet.contains( entry.getKey() ) ) {
+        ColumnBinary childColumnBinary = null;
+        result += entry.getValue().metaSizeAfterAppend( childColumnBinary );
+      }
+    }
+
+    for ( String columnName : childKeyList ) {
+      byte[] childNameBytes = columnName.getBytes( "UTF-8" );
+      result += Integer.BYTES + childNameBytes.length;
+    }
+    return result;
+  }
+
+  /**
+   * append size.
+   */
+  public int metaSizeAfterAppend( final List<ColumnBinary> rootBinaryList ) throws IOException {
+    int result = 0;
+    // child size
+    result += Integer.BYTES;
+    // binaryOffsetMetaData
+    result += Integer.BYTES * 3;
+    Set<String> childKeySet = new HashSet<String>();
+    for ( ColumnBinary childColumnBinary : rootBinaryList ) {
+      ColumnBinaryTree childTree = childTreeMap.get( childColumnBinary.columnName );
+      if ( childTree == null ) {
+        byte[] childNameBytes = childColumnBinary.columnName.getBytes( "UTF-8" );
+        result += Integer.BYTES + childNameBytes.length;
+        childTree = new ColumnBinaryTree();
+        while ( childTree.size() < ( getChildSize() ) ) {
+          childTree.add( null );
+        }
+      }
+      result += childTree.metaSizeAfterAppend( childColumnBinary );
+      childKeySet.add( childColumnBinary.columnName );
+    }
+
+    for ( Map.Entry<String,ColumnBinaryTree> entry : childTreeMap.entrySet() ) {
+      if ( ! childKeySet.contains( entry.getKey() ) ) {
+        ColumnBinary childColumnBinary = null;
+        result += entry.getValue().metaSizeAfterAppend( childColumnBinary );
+      }
+    }
+    
+    for ( String columnName : childKeyList ) {
+      byte[] childNameBytes = columnName.getBytes( "UTF-8" );
+      result += Integer.BYTES + childNameBytes.length;
+    }
+
+    return result;
+  }
+
+  /**
+   * Data size after append.
+   */
+  public int dataSizeAfterAppend( final List<ColumnBinary> rootBinaryList ) throws IOException {
+    int result = dataSize();
+    for ( ColumnBinary binary : rootBinaryList ) {
+      result += binary.size();
+    }
+    return result;
+  }
+
+  /**
+   * Data size.
+   */
+  public int dataSize() {
+    int result = dataSize;
+    for ( Map.Entry<String,ColumnBinaryTree> entry : childTreeMap.entrySet() ) {
+      result += entry.getValue().dataSize();
+    }
+    return result;
+  }
+
+  /**
    * Write data.
    */
   public int writeData( final OutputStream out ) throws IOException {
@@ -372,6 +498,7 @@ public class ColumnBinaryTree {
     currentCount = 0;
     childCount = 0;
     metaLength = 0;
+    dataSize = 0;
     allBinaryLength = 0;
   }
 

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/BlockIndexNode.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/BlockIndexNode.java
@@ -25,13 +25,26 @@ import java.util.Map;
 
 public class BlockIndexNode {
 
-  private final Map<String,BlockIndexNode> childContainer;
-
+  private Map<String,BlockIndexNode> childContainer;
   private IBlockIndex blockIndex;
   private boolean isDisable;
 
   public BlockIndexNode() {
     childContainer = new HashMap<String,BlockIndexNode>();
+  }
+
+  @Override
+  public BlockIndexNode clone() {
+    BlockIndexNode result = new BlockIndexNode();
+    result.childContainer = new HashMap<String,BlockIndexNode>();
+    for ( Map.Entry<String,BlockIndexNode> entry : childContainer.entrySet() ) {
+      result.childContainer.put( entry.getKey() , entry.getValue().clone() );
+    }
+    if ( blockIndex != null ) { 
+      result.blockIndex = blockIndex.clone();
+    }
+    result.isDisable = isDisable;
+    return result;
   }
 
   /**

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/ByteRangeBlockIndex.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/ByteRangeBlockIndex.java
@@ -43,6 +43,11 @@ public class ByteRangeBlockIndex implements IBlockIndex {
   }
 
   @Override
+  public IBlockIndex clone() {
+    return new ByteRangeBlockIndex( min , max );
+  }
+
+  @Override
   public BlockIndexType getBlockIndexType() {
     return BlockIndexType.RANGE_BYTE;
   }

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/DoubleRangeBlockIndex.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/DoubleRangeBlockIndex.java
@@ -43,6 +43,11 @@ public class DoubleRangeBlockIndex implements IBlockIndex {
   }
 
   @Override
+  public IBlockIndex clone() {
+    return new DoubleRangeBlockIndex( min , max );
+  }
+
+  @Override
   public BlockIndexType getBlockIndexType() {
     return BlockIndexType.RANGE_DOUBLE;
   }

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/FloatRangeBlockIndex.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/FloatRangeBlockIndex.java
@@ -43,6 +43,11 @@ public class FloatRangeBlockIndex implements IBlockIndex {
   }
 
   @Override
+  public IBlockIndex clone() {
+    return new FloatRangeBlockIndex( min , max );
+  }
+
+  @Override
   public BlockIndexType getBlockIndexType() {
     return BlockIndexType.RANGE_FLOAT;
   }

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/FullRangeBlockIndex.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/FullRangeBlockIndex.java
@@ -68,6 +68,20 @@ public class FullRangeBlockIndex implements IBlockIndex {
       return blockIndex;
     }
 
+    @Override
+    public RangeBlockIndex clone() {
+      return new RangeBlockIndex( index , blockIndex.clone() );
+    }
+
+  }
+
+  @Override
+  public IBlockIndex clone() {
+    FullRangeBlockIndex result = new FullRangeBlockIndex();
+    for ( RangeBlockIndex rangeBlockIndex : childList ) {
+      result.childList.add( rangeBlockIndex.clone() );
+    }
+    return result;
   }
 
   /**

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/IntegerRangeBlockIndex.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/IntegerRangeBlockIndex.java
@@ -43,6 +43,11 @@ public class IntegerRangeBlockIndex implements IBlockIndex {
   }
 
   @Override
+  public IBlockIndex clone() {
+    return new IntegerRangeBlockIndex( min , max );
+  }
+
+  @Override
   public BlockIndexType getBlockIndexType() {
     return BlockIndexType.RANGE_INTEGER;
   }

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/LongRangeBlockIndex.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/LongRangeBlockIndex.java
@@ -43,6 +43,11 @@ public class LongRangeBlockIndex implements IBlockIndex {
   }
 
   @Override
+  public IBlockIndex clone() {
+    return new LongRangeBlockIndex( min , max );
+  }
+
+  @Override
   public BlockIndexType getBlockIndexType() {
     return BlockIndexType.RANGE_LONG;
   }

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/ShortRangeBlockIndex.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/ShortRangeBlockIndex.java
@@ -43,6 +43,11 @@ public class ShortRangeBlockIndex implements IBlockIndex {
   }
 
   @Override
+  public IBlockIndex clone() {
+    return new ShortRangeBlockIndex( min , max );
+  }
+
+  @Override
   public BlockIndexType getBlockIndexType() {
     return BlockIndexType.RANGE_SHORT;
   }

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/StringRangeBlockIndex.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/StringRangeBlockIndex.java
@@ -46,6 +46,11 @@ public class StringRangeBlockIndex implements IBlockIndex {
   }
 
   @Override
+  public IBlockIndex clone() {
+    return new StringRangeBlockIndex( min , max );
+  }
+
+  @Override
   public BlockIndexType getBlockIndexType() {
     return BlockIndexType.RANGE_STRING;
   }

--- a/src/main/java/jp/co/yahoo/yosegi/blockindex/UnsupportedBlockIndex.java
+++ b/src/main/java/jp/co/yahoo/yosegi/blockindex/UnsupportedBlockIndex.java
@@ -27,6 +27,11 @@ public class UnsupportedBlockIndex implements IBlockIndex {
   public static final IBlockIndex INSTANCE = new UnsupportedBlockIndex();
 
   @Override
+  public IBlockIndex clone() {
+    return INSTANCE;
+  }
+
+  @Override
   public BlockIndexType getBlockIndexType() {
     return BlockIndexType.UNSUPPORTED;
   }

--- a/src/test/java/jp/co/yahoo/yosegi/binary/TestColumnBinary.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/TestColumnBinary.java
@@ -46,7 +46,7 @@ public class TestColumnBinary{
     assertEquals( columnBinary.binaryLength , 90 );
     assertEquals( columnBinary.columnBinaryList , null );
 
-    assertTrue( 0 < columnBinary.size() );
+    assertTrue( 0 < columnBinary.binarySize() );
     assertTrue( 0 < columnBinary.getMetaSize() );
   }
 
@@ -69,7 +69,7 @@ public class TestColumnBinary{
     assertEquals( columnBinary.binaryLength , 90 );
     assertEquals( columnBinary.columnBinaryList , null );
 
-    assertTrue( 0 < parentColumnBinary.size() );
+    assertTrue( 0 < parentColumnBinary.binarySize() );
     assertTrue( 0 < parentColumnBinary.getMetaSize() );
   }
 
@@ -91,7 +91,7 @@ public class TestColumnBinary{
     assertEquals( columnBinary.binaryLength , 90 );
     assertEquals( columnBinary.columnBinaryList , null );
 
-    assertTrue( 0 < columnBinary.size() );
+    assertTrue( 0 < columnBinary.binarySize() );
     assertTrue( 0 < columnBinary.getMetaSize() );
   }
 

--- a/src/test/java/jp/co/yahoo/yosegi/block/BlockTestCompressor.java
+++ b/src/test/java/jp/co/yahoo/yosegi/block/BlockTestCompressor.java
@@ -15,29 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package jp.co.yahoo.yosegi.block;
 
-package jp.co.yahoo.yosegi.blockindex;
+import jp.co.yahoo.yosegi.compressor.CompressResult;
+import jp.co.yahoo.yosegi.compressor.DefaultCompressor;
 
-import jp.co.yahoo.yosegi.spread.column.filter.IFilter;
+import java.io.IOException;
 
-import java.util.List;
-
-public interface IBlockIndex {
-
-  BlockIndexType getBlockIndexType();
-
-  IBlockIndex clone();
-
-  boolean merge( final IBlockIndex blockIndex );
-
-  int getBinarySize();
-
-  byte[] toBinary();
-
-  void setFromBinary( final byte[] buffer , final int start , final int length );
-
-  List<Integer> getBlockSpreadIndex( final IFilter filter );
-
-  IBlockIndex getNewInstance();
-
+public class BlockTestCompressor extends DefaultCompressor {
+  @Override
+  public byte[] compress(
+      final byte[] data ,
+      final int start ,
+      final int length ,
+      final CompressResult compressResult ) throws IOException {
+    byte[] result = new byte[length+1];
+    System.arraycopy( data , start , result , 0 , length );
+    return result;
+  }
 }

--- a/src/test/java/jp/co/yahoo/yosegi/block/TestColumnBinaryTree.java
+++ b/src/test/java/jp/co/yahoo/yosegi/block/TestColumnBinaryTree.java
@@ -17,25 +17,94 @@
  */
 package jp.co.yahoo.yosegi.block;
 
-import java.io.IOException;
-
-import java.util.List;
-import java.util.ArrayList;
-
-import java.util.stream.Stream;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
+import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
+import jp.co.yahoo.yosegi.binary.maker.IColumnBinaryMaker;
+import jp.co.yahoo.yosegi.binary.maker.UnsafeOptimizeDumpStringColumnBinaryMaker;
+import jp.co.yahoo.yosegi.binary.maker.DumpSpreadColumnBinaryMaker;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
+import jp.co.yahoo.yosegi.message.objects.StringObj;
+import jp.co.yahoo.yosegi.spread.Spread;
+import jp.co.yahoo.yosegi.spread.column.ColumnType;
+import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
+import jp.co.yahoo.yosegi.spread.column.filter.*;
+import jp.co.yahoo.yosegi.spread.expression.*;
+import jp.co.yahoo.yosegi.util.ByteArrayData;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import jp.co.yahoo.yosegi.binary.ColumnBinary;
-import jp.co.yahoo.yosegi.spread.column.ColumnType;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class TestColumnBinaryTree{
+
+  private List<ColumnBinary> createSingleCaseData() throws IOException {
+    IColumn column = new PrimitiveColumn( ColumnType.STRING , "column1" );
+    column.add( ColumnType.STRING , new StringObj( "a" ) , 0 );
+    column.add( ColumnType.STRING , new StringObj( "ab" ) , 1 );
+    column.add( ColumnType.STRING , new StringObj( "abc" ) , 2 );
+    column.add( ColumnType.STRING , new StringObj( "abcd" ) , 3 );
+    column.add( ColumnType.STRING , new StringObj( "b" ) , 4 );
+    column.add( ColumnType.STRING , new StringObj( "bc" ) , 5 );
+    column.add( ColumnType.STRING , new StringObj( "bcd" ) , 6 );
+    column.add( ColumnType.STRING , new StringObj( "bcde" ) , 7 );
+    column.add( ColumnType.STRING , new StringObj( "c" ) , 8 );
+    column.add( ColumnType.STRING , new StringObj( "cd" ) , 9 );
+
+    UnsafeOptimizeDumpStringColumnBinaryMaker maker = new UnsafeOptimizeDumpStringColumnBinaryMaker();
+    ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+    ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
+
+    return Arrays.asList(
+        maker.toBinary( defaultConfig , null , new CompressResultNode() , column ) ); 
+  }
+
+  private List<ColumnBinary> createSimpleCaseData() throws IOException {
+    IColumn column = new PrimitiveColumn( ColumnType.STRING , "column1" );
+    column.add( ColumnType.STRING , new StringObj( "a" ) , 0 );
+    column.add( ColumnType.STRING , new StringObj( "ab" ) , 1 );
+    column.add( ColumnType.STRING , new StringObj( "abc" ) , 2 );
+    column.add( ColumnType.STRING , new StringObj( "abcd" ) , 3 );
+    column.add( ColumnType.STRING , new StringObj( "b" ) , 4 );
+    column.add( ColumnType.STRING , new StringObj( "bc" ) , 5 );
+    column.add( ColumnType.STRING , new StringObj( "bcd" ) , 6 );
+    column.add( ColumnType.STRING , new StringObj( "bcde" ) , 7 );
+    column.add( ColumnType.STRING , new StringObj( "c" ) , 8 );
+    column.add( ColumnType.STRING , new StringObj( "cd" ) , 9 );
+
+    IColumn column2 = new PrimitiveColumn( ColumnType.STRING , "column2" );
+    column2.add( ColumnType.STRING , new StringObj( "a" ) , 0 );
+    column2.add( ColumnType.STRING , new StringObj( "ab" ) , 1 );
+    column2.add( ColumnType.STRING , new StringObj( "abc" ) , 2 );
+    column2.add( ColumnType.STRING , new StringObj( "abcd" ) , 3 );
+    column2.add( ColumnType.STRING , new StringObj( "b" ) , 4 );
+    column2.add( ColumnType.STRING , new StringObj( "bc" ) , 5 );
+    column2.add( ColumnType.STRING , new StringObj( "bcd" ) , 6 );
+    column2.add( ColumnType.STRING , new StringObj( "bcde" ) , 7 );
+    column2.add( ColumnType.STRING , new StringObj( "c" ) , 8 );
+    column2.add( ColumnType.STRING , new StringObj( "cd" ) , 9 );
+
+    UnsafeOptimizeDumpStringColumnBinaryMaker maker = new UnsafeOptimizeDumpStringColumnBinaryMaker();
+    ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+    ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
+
+    return Arrays.asList(
+        maker.toBinary( defaultConfig , null , new CompressResultNode() , column ) ,
+        maker.toBinary( defaultConfig , null , new CompressResultNode() , column2 ) );
+
+  }
 
   @Test
   public void T_getColumnBinary_1() throws IOException{
@@ -65,6 +134,315 @@ public class TestColumnBinaryTree{
     assertEquals( tree.getColumnBinary( 0 ).columnName , "test"  );
   }
 
+  @Test
+  public void T_metaSizeAfterAppend_equalsMetaBinarySize_withOnce() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSimpleCaseData();
+    int metaSizeAfterAppend = tree.metaSizeAfterAppend( list );
+    tree.addChild( list );
+    assertEquals( metaSizeAfterAppend , tree.metaSize() );
 
+    ByteArrayData byteArrayData = new ByteArrayData();
+    tree.createMeta( byteArrayData , 0 );
+    assertEquals( byteArrayData.getLength() , metaSizeAfterAppend );
+  }
+
+  @Test
+  public void T_metaSizeAfterAppend_equalsMetaBinarySize_withSomeList() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSimpleCaseData();
+    tree.addChild( list );
+    tree.addChild( list );
+    tree.addChild( list );
+    tree.addChild( list );
+    int metaSizeAfterAppend = tree.metaSizeAfterAppend( list );
+    tree.addChild( list );
+    assertEquals( metaSizeAfterAppend , tree.metaSize() );
+
+    ByteArrayData byteArrayData = new ByteArrayData();
+    tree.createMeta( byteArrayData , 0 );
+    assertEquals( byteArrayData.getLength() , metaSizeAfterAppend );
+  }
+
+  @Test
+  public void T_metaSizeAfterAppend_equalsMetaBinarySize_withOneColumnAfterTwoColumns() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSingleCaseData();
+    tree.addChild( list );
+    List<ColumnBinary> list2 = createSimpleCaseData();
+    int metaSizeAfterAppend = tree.metaSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( metaSizeAfterAppend , tree.metaSize() );
+
+    ByteArrayData byteArrayData = new ByteArrayData();
+    tree.createMeta( byteArrayData , 0 );
+    assertEquals( byteArrayData.getLength() , metaSizeAfterAppend );
+  }
+
+  @Test
+  public void T_metaSizeAfterAppend_equalsMetaBinarySize_withTwoColumnsAfterOneColumn() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSimpleCaseData();
+    tree.addChild( list );
+    List<ColumnBinary> list2 = createSingleCaseData();
+    int metaSizeAfterAppend = tree.metaSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( metaSizeAfterAppend , tree.metaSize() );
+
+    ByteArrayData byteArrayData = new ByteArrayData();
+    tree.createMeta( byteArrayData , 0 );
+    assertEquals( byteArrayData.getLength() , metaSizeAfterAppend );
+  }
+
+  @Test
+  public void T_metaSizeAfterAppend_equalsMetaBinarySize_withNestedSimpleCaseChild() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> childList = createSimpleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    int metaSizeAfterAppend = tree.metaSizeAfterAppend( list );
+    tree.addChild( list );
+
+    ByteArrayData byteArrayData = new ByteArrayData();
+    tree.createMeta( byteArrayData , 0 );
+    assertEquals( byteArrayData.getLength() , metaSizeAfterAppend );
+  }
+
+  @Test
+  public void T_metaSizeAfterAppend_equalsMetaBinarySize_withSomeNestedSimpleCaseChild() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> childList = createSimpleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    tree.addChild( list );
+    tree.addChild( list );
+    tree.addChild( list );
+    tree.addChild( list );
+    int metaSizeAfterAppend = tree.metaSizeAfterAppend( list );
+    tree.addChild( list );
+    assertEquals( metaSizeAfterAppend , tree.metaSize() );
+
+    ByteArrayData byteArrayData = new ByteArrayData();
+    tree.createMeta( byteArrayData , 0 );
+    assertEquals( byteArrayData.getLength() , metaSizeAfterAppend );
+  }
+
+  @Test
+  public void T_metaSizeAfterAppend_equalsMetaBinarySize_withNestedFirstOneColumnAfterTwoColumn() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> childList = createSingleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    tree.addChild( list );
+
+    List<ColumnBinary> childList2 = createSimpleCaseData();
+    List<ColumnBinary> list2 = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList2 ) );
+    int metaSizeAfterAppend = tree.metaSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( metaSizeAfterAppend , tree.metaSize() );
+
+    ByteArrayData byteArrayData = new ByteArrayData();
+    tree.createMeta( byteArrayData , 0 );
+    assertEquals( byteArrayData.getLength() , metaSizeAfterAppend );
+  }
+
+  @Test
+  public void T_metaSizeAfterAppend_equalsMetaBinarySize_withNestedFirstTwoColumnsAfterOneColumn() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> childList = createSimpleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    tree.addChild( list );
+
+    List<ColumnBinary> childList2 = createSingleCaseData();
+    List<ColumnBinary> list2 = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList2 ) );
+    int metaSizeAfterAppend = tree.metaSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( metaSizeAfterAppend , tree.metaSize() );
+
+    ByteArrayData byteArrayData = new ByteArrayData();
+    tree.createMeta( byteArrayData , 0 );
+    assertEquals( byteArrayData.getLength() , metaSizeAfterAppend );
+  }
+
+  @Test
+  public void T_metaSizeAfterAppend_equalsMetaBinarySize_withNestedFirstIsNoting() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSimpleCaseData();
+    tree.addChild( list );
+
+    List<ColumnBinary> childList2 = createSimpleCaseData();
+    List<ColumnBinary> list2 = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList2 ) );
+    int metaSizeAfterAppend = tree.metaSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( metaSizeAfterAppend , tree.metaSize() );
+
+    ByteArrayData byteArrayData = new ByteArrayData();
+    tree.createMeta( byteArrayData , 0 );
+    assertEquals( byteArrayData.getLength() , metaSizeAfterAppend );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withOnce() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSimpleCaseData();
+    int dataSizeAfterAppend = tree.dataSizeAfterAppend( list );
+    tree.addChild( list );
+    assertEquals( dataSizeAfterAppend , tree.dataSize() );
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    tree.writeData( out );
+    byte[] data = out.toByteArray();
+    assertEquals( data.length , dataSizeAfterAppend );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withSomeList() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSimpleCaseData();
+    tree.addChild( list );
+    tree.addChild( list );
+    tree.addChild( list );
+    tree.addChild( list );
+    int dataSizeAfterAppend = tree.dataSizeAfterAppend( list );
+    tree.addChild( list );
+    assertEquals( dataSizeAfterAppend , tree.dataSize() );
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    tree.writeData( out );
+    byte[] data = out.toByteArray();
+    assertEquals( data.length , dataSizeAfterAppend );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withOneColumnAfterTwoColumns() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSingleCaseData();
+    tree.addChild( list );
+    List<ColumnBinary> list2 = createSimpleCaseData();
+    int dataSizeAfterAppend = tree.dataSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( dataSizeAfterAppend , tree.dataSize() );
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    tree.writeData( out );
+    byte[] data = out.toByteArray();
+    assertEquals( data.length , dataSizeAfterAppend );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withTwoColumnsAfterOneColumn() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSimpleCaseData();
+    tree.addChild( list );
+    List<ColumnBinary> list2 = createSingleCaseData();
+    int dataSizeAfterAppend = tree.dataSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( dataSizeAfterAppend , tree.dataSize() );
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    tree.writeData( out );
+    byte[] data = out.toByteArray();
+    assertEquals( data.length , dataSizeAfterAppend );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withNestedSimpleCaseChild() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> childList = createSimpleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    int dataSizeAfterAppend = tree.dataSizeAfterAppend( list );
+    tree.addChild( list );
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    tree.writeData( out );
+    byte[] data = out.toByteArray();
+    assertEquals( data.length , dataSizeAfterAppend );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withSomeNestedSimpleCaseChild() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> childList = createSimpleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    tree.addChild( list );
+    tree.addChild( list );
+    tree.addChild( list );
+    tree.addChild( list );
+    int dataSizeAfterAppend = tree.dataSizeAfterAppend( list );
+    tree.addChild( list );
+    assertEquals( dataSizeAfterAppend , tree.dataSize() );
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    tree.writeData( out );
+    byte[] data = out.toByteArray();
+    assertEquals( data.length , dataSizeAfterAppend );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withNestedFirstOneColumnAfterTwoColumn() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> childList = createSingleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    tree.addChild( list );
+
+    List<ColumnBinary> childList2 = createSimpleCaseData();
+    List<ColumnBinary> list2 = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList2 ) );
+    int dataSizeAfterAppend = tree.dataSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( dataSizeAfterAppend , tree.dataSize() );
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    tree.writeData( out );
+    byte[] data = out.toByteArray();
+    assertEquals( data.length , dataSizeAfterAppend );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withNestedFirstTwoColumnsAfterOneColumn() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> childList = createSimpleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    tree.addChild( list );
+
+    List<ColumnBinary> childList2 = createSingleCaseData();
+    List<ColumnBinary> list2 = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList2 ) );
+    int dataSizeAfterAppend = tree.dataSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( dataSizeAfterAppend , tree.dataSize() );
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    tree.writeData( out );
+    byte[] data = out.toByteArray();
+    assertEquals( data.length , dataSizeAfterAppend );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withNestedFirstIsNoting() throws IOException {
+    ColumnBinaryTree tree = new ColumnBinaryTree();
+    List<ColumnBinary> list = createSimpleCaseData();
+    tree.addChild( list );
+
+    List<ColumnBinary> childList2 = createSimpleCaseData();
+    List<ColumnBinary> list2 = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList2 ) );
+    int dataSizeAfterAppend = tree.dataSizeAfterAppend( list2 );
+    tree.addChild( list2 );
+    assertEquals( dataSizeAfterAppend , tree.dataSize() );
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    tree.writeData( out );
+    byte[] data = out.toByteArray();
+    assertEquals( data.length , dataSizeAfterAppend );
+  }
 
 }

--- a/src/test/java/jp/co/yahoo/yosegi/block/TestPushdownSupportedBlockWriter.java
+++ b/src/test/java/jp/co/yahoo/yosegi/block/TestPushdownSupportedBlockWriter.java
@@ -22,10 +22,16 @@ import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
 import jp.co.yahoo.yosegi.binary.CompressResultNode;
+import jp.co.yahoo.yosegi.binary.maker.DumpBooleanColumnBinaryMaker;
+import jp.co.yahoo.yosegi.binary.maker.DumpSpreadColumnBinaryMaker;
 import jp.co.yahoo.yosegi.binary.maker.IColumnBinaryMaker;
 import jp.co.yahoo.yosegi.binary.maker.UnsafeOptimizeDumpStringColumnBinaryMaker;
+import jp.co.yahoo.yosegi.compressor.CompressResult;
+import jp.co.yahoo.yosegi.compressor.DefaultCompressor;
+import jp.co.yahoo.yosegi.compressor.GzipCompressor;
 import jp.co.yahoo.yosegi.config.Configuration;
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
+import jp.co.yahoo.yosegi.message.objects.BooleanObj;
 import jp.co.yahoo.yosegi.message.objects.StringObj;
 import jp.co.yahoo.yosegi.spread.Spread;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
@@ -52,7 +58,40 @@ import java.util.Map;
 
 public class TestPushdownSupportedBlockWriter {
 
-  private List<ColumnBinary> createTestData() throws IOException {
+  private List<ColumnBinary> createCompressMetaCaseData() throws IOException {
+    IColumn column = new PrimitiveColumn( ColumnType.BOOLEAN , "c" );
+    column.add( ColumnType.BOOLEAN , new BooleanObj( true ) , 0 );
+
+    DumpBooleanColumnBinaryMaker maker = new DumpBooleanColumnBinaryMaker();
+    ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+    ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
+
+    return Arrays.asList(
+        maker.toBinary( defaultConfig , null , new CompressResultNode() , column ) );
+  }
+
+  private List<ColumnBinary> createSingleCaseData() throws IOException {
+    IColumn column = new PrimitiveColumn( ColumnType.STRING , "column1" );
+    column.add( ColumnType.STRING , new StringObj( "a" ) , 0 );
+    column.add( ColumnType.STRING , new StringObj( "ab" ) , 1 );
+    column.add( ColumnType.STRING , new StringObj( "abc" ) , 2 );
+    column.add( ColumnType.STRING , new StringObj( "abcd" ) , 3 );
+    column.add( ColumnType.STRING , new StringObj( "b" ) , 4 );
+    column.add( ColumnType.STRING , new StringObj( "bc" ) , 5 );
+    column.add( ColumnType.STRING , new StringObj( "bcd" ) , 6 );
+    column.add( ColumnType.STRING , new StringObj( "bcde" ) , 7 );
+    column.add( ColumnType.STRING , new StringObj( "c" ) , 8 );
+    column.add( ColumnType.STRING , new StringObj( "cd" ) , 9 );
+
+    UnsafeOptimizeDumpStringColumnBinaryMaker maker = new UnsafeOptimizeDumpStringColumnBinaryMaker();
+    ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+    ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
+
+    return Arrays.asList(
+        maker.toBinary( defaultConfig , null , new CompressResultNode() , column ) );
+  }
+
+  private List<ColumnBinary> createSimpleCaseData() throws IOException {
     IColumn column = new PrimitiveColumn( ColumnType.STRING , "column1" );
     column.add( ColumnType.STRING , new StringObj( "a" ) , 0 );
     column.add( ColumnType.STRING , new StringObj( "ab" ) , 1 );
@@ -88,14 +127,463 @@ public class TestPushdownSupportedBlockWriter {
   }
 
   @Test
-  public void T_appendAndSize_equalsAppendBinarySize() throws IOException {
+  public void T_appendAndSize_equalsAppendBinarySize_withOnceList() throws IOException {
     PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
     writer.setup( 1024 * 1024 * 8 , new Configuration() );
-    List<ColumnBinary> list = createTestData();
+    List<ColumnBinary> list = createSimpleCaseData();
     int sizeAfterAppend = writer.sizeAfterAppend( list );
     writer.append( 10 , list );
     assertEquals( writer.size() , sizeAfterAppend );
-    
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( outputDataSize , block.length );
+  }
+
+  @Test
+  public void T_appendAndSize_equalsAppendBinarySize_withSomeList() throws IOException {
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( 1024 * 1024 * 8 , new Configuration() );
+    List<ColumnBinary> list = createSimpleCaseData();
+    writer.append( 10 , list );
+    writer.append( 10 , list );
+    writer.append( 10 , list );
+    writer.append( 10 , list );
+    int sizeAfterAppend = writer.sizeAfterAppend( list );
+    writer.append( 10 , list );
+    assertEquals( writer.size() , sizeAfterAppend );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( outputDataSize , block.length );
+  }
+
+  @Test
+  public void T_appendAndSize_equalsAppendBinarySize_withOneColumnAfterTwoColumns() throws IOException {
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( 1024 * 1024 * 8 , new Configuration() );
+    List<ColumnBinary> list = createSingleCaseData();
+    writer.append( 10 , list );
+    List<ColumnBinary> list2 = createSimpleCaseData();
+    int sizeAfterAppend = writer.sizeAfterAppend( list2 );
+    writer.append( 10 , list2 );
+    assertEquals( writer.size() , sizeAfterAppend );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( outputDataSize , block.length );
+  }
+
+  @Test
+  public void T_appendAndSize_equalsAppendBinarySize_withTwoColumnsAfterOneColumn() throws IOException {
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( 1024 * 1024 * 8 , new Configuration() );
+    List<ColumnBinary> list = createSimpleCaseData();
+    writer.append( 10 , list );
+    List<ColumnBinary> list2 = createSingleCaseData();
+    int sizeAfterAppend = writer.sizeAfterAppend( list2 );
+    writer.append( 10 , list2 );
+    assertEquals( writer.size() , sizeAfterAppend );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( outputDataSize , block.length );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withNestedSimpleCaseChild() throws IOException {
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( 1024 * 1024 * 8 , new Configuration() );
+    List<ColumnBinary> childList = createSimpleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    int sizeAfterAppend = writer.sizeAfterAppend( list );
+    writer.append( 10 , list );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( outputDataSize , block.length );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withSomeNestedSimpleCaseChild() throws IOException {
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( 1024 * 1024 * 8 , new Configuration() );
+    List<ColumnBinary> childList = createSimpleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    writer.append( 10 , list );
+    writer.append( 10 , list );
+    writer.append( 10 , list );
+    writer.append( 10 , list );
+    int sizeAfterAppend = writer.sizeAfterAppend( list );
+    writer.append( 10 , list );
+    assertEquals( writer.size() , sizeAfterAppend );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( outputDataSize , block.length );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withNestedFirstOneColumnAfterTwoColumn() throws IOException {
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( 1024 * 1024 * 8 , new Configuration() );
+    List<ColumnBinary> childList = createSingleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    writer.append( 10 , list );
+
+    List<ColumnBinary> childList2 = createSimpleCaseData();
+    List<ColumnBinary> list2 = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList2 ) );
+    int sizeAfterAppend = writer.sizeAfterAppend( list2 );
+    writer.append( 10 , list2 );
+    assertEquals( writer.size() , sizeAfterAppend );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( outputDataSize , block.length );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withNestedFirstTwoColumnsAfterOneColumn() throws IOException {
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( 1024 * 1024 * 8 , new Configuration() );
+    List<ColumnBinary> childList = createSimpleCaseData();
+    List<ColumnBinary> list = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList ) );
+    writer.append( 10 , list );
+
+    List<ColumnBinary> childList2 = createSingleCaseData();
+    List<ColumnBinary> list2 = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList2 ) );
+    int sizeAfterAppend = writer.sizeAfterAppend( list2 );
+    writer.append( 10 , list2 );
+    assertEquals( writer.size() , sizeAfterAppend );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( outputDataSize , block.length );
+  }
+
+  @Test
+  public void T_dataSizeAfterAppend_equalsDataBinarySize_withNestedFirstIsNoting() throws IOException {
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( 1024 * 1024 * 8 , new Configuration() );
+    List<ColumnBinary> list = createSimpleCaseData();
+    writer.append( 10 , list );
+
+    List<ColumnBinary> childList2 = createSimpleCaseData();
+    List<ColumnBinary> list2 = Arrays.asList( DumpSpreadColumnBinaryMaker.createSpreadColumnBinary(
+        "parent" , 10 , childList2 ) );
+    int sizeAfterAppend = writer.sizeAfterAppend( list2 );
+    writer.append( 10 , list2 );
+    assertEquals( writer.size() , sizeAfterAppend );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( outputDataSize , block.length );
+  }
+
+  @Test
+  public void T_blockSizeEqualsBlockBinarySize_equalsBlockSizeAndRead_withVariableBlock() throws IOException {
+    PushdownSupportedBlockWriter tmpWriter = new PushdownSupportedBlockWriter();
+    tmpWriter.setup( 1024 * 1024 * 8 , new Configuration() );
+
+    List<ColumnBinary> list = createSimpleCaseData();
+    tmpWriter.append( 10 , list );
+    tmpWriter.append( 10 , list );
+    int blockSize = tmpWriter.size();
+    tmpWriter.close();
+
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( blockSize , new Configuration() );
+    writer.append( 10 , list );
+    assertTrue( writer.canAppend( list ) );
+    writer.append( 10 , list );
+    assertEquals( writer.size() , blockSize );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( blockSize , block.length );
+
+    PushdownSupportedBlockReader reader = new PushdownSupportedBlockReader();
+    ByteArrayInputStream in = new ByteArrayInputStream( block );
+    reader.setup( new Configuration() );
+    reader.setStream( in , blockSize );
+    assertEquals( 2 , reader.getBlockCount() );
+    while ( reader.hasNext() ) {
+      Spread spread = reader.next();
+      IColumn c1 = spread.getColumn( "column1" );
+      PrimitiveObject[] c1Array = c1.getPrimitiveObjectArray( new AllExpressionIndex( 10 ) , 0 , 10 );
+      assertEquals( c1Array[0].getString() , "a" );
+      assertEquals( c1Array[1].getString() , "ab" );
+      assertEquals( c1Array[2].getString() , "abc" );
+      assertEquals( c1Array[3].getString() , "abcd" );
+      assertEquals( c1Array[4].getString() , "b" );
+      assertEquals( c1Array[5].getString() , "bc" );
+      assertEquals( c1Array[6].getString() , "bcd" );
+      assertEquals( c1Array[7].getString() , "bcde" );
+      assertEquals( c1Array[8].getString() , "c" );
+      assertEquals( c1Array[9].getString() , "cd" );
+      IColumn c2 = spread.getColumn( "column2" );
+      PrimitiveObject[] c2Array = c1.getPrimitiveObjectArray( new AllExpressionIndex( 10 ) , 0 , 10 );
+      assertEquals( c2Array[0].getString() , "a" );
+      assertEquals( c2Array[1].getString() , "ab" );
+      assertEquals( c2Array[2].getString() , "abc" );
+      assertEquals( c2Array[3].getString() , "abcd" );
+      assertEquals( c2Array[4].getString() , "b" );
+      assertEquals( c2Array[5].getString() , "bc" );
+      assertEquals( c2Array[6].getString() , "bcd" );
+      assertEquals( c2Array[7].getString() , "bcde" );
+      assertEquals( c2Array[8].getString() , "c" );
+      assertEquals( c2Array[9].getString() , "cd" );
+    }
+    reader.close();
+  }
+
+  @Test
+  public void T_blockSizeEqualsBlockBinarySize_equalsBlockSizeAndRead_withFixedBlock() throws IOException {
+    PushdownSupportedBlockWriter tmpWriter = new PushdownSupportedBlockWriter();
+    tmpWriter.setup( 1024 * 1024 * 8 , new Configuration() );
+
+    List<ColumnBinary> list = createSimpleCaseData();
+    tmpWriter.append( 10 , list );
+    tmpWriter.append( 10 , list );
+    int blockSize = tmpWriter.size();
+    tmpWriter.close();
+
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( blockSize , new Configuration() );
+    writer.append( 10 , list );
+    assertTrue( writer.canAppend( list ) );
+    writer.append( 10 , list );
+    assertEquals( writer.size() , blockSize );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeFixedBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( blockSize , block.length );
+
+    PushdownSupportedBlockReader reader = new PushdownSupportedBlockReader();
+    ByteArrayInputStream in = new ByteArrayInputStream( block );
+    reader.setup( new Configuration() );
+    reader.setStream( in , blockSize );
+    assertEquals( 2 , reader.getBlockCount() );
+    while ( reader.hasNext() ) {
+      Spread spread = reader.next();
+      IColumn c1 = spread.getColumn( "column1" );
+      PrimitiveObject[] c1Array = c1.getPrimitiveObjectArray( new AllExpressionIndex( 10 ) , 0 , 10 );
+      assertEquals( c1Array[0].getString() , "a" );
+      assertEquals( c1Array[1].getString() , "ab" );
+      assertEquals( c1Array[2].getString() , "abc" );
+      assertEquals( c1Array[3].getString() , "abcd" );
+      assertEquals( c1Array[4].getString() , "b" );
+      assertEquals( c1Array[5].getString() , "bc" );
+      assertEquals( c1Array[6].getString() , "bcd" );
+      assertEquals( c1Array[7].getString() , "bcde" );
+      assertEquals( c1Array[8].getString() , "c" );
+      assertEquals( c1Array[9].getString() , "cd" );
+      IColumn c2 = spread.getColumn( "column2" );
+      PrimitiveObject[] c2Array = c1.getPrimitiveObjectArray( new AllExpressionIndex( 10 ) , 0 , 10 );
+      assertEquals( c2Array[0].getString() , "a" );
+      assertEquals( c2Array[1].getString() , "ab" );
+      assertEquals( c2Array[2].getString() , "abc" );
+      assertEquals( c2Array[3].getString() , "abcd" );
+      assertEquals( c2Array[4].getString() , "b" );
+      assertEquals( c2Array[5].getString() , "bc" );
+      assertEquals( c2Array[6].getString() , "bcd" );
+      assertEquals( c2Array[7].getString() , "bcde" );
+      assertEquals( c2Array[8].getString() , "c" );
+      assertEquals( c2Array[9].getString() , "cd" );
+    }
+    reader.close();
+  }
+
+  @Test
+  public void T_blockSizeEqualsHeaderAppendBlockBinary_equals_withVariableBlock() throws IOException {
+    PushdownSupportedBlockWriter tmpWriter = new PushdownSupportedBlockWriter();
+    tmpWriter.setup( 1024 * 1024 * 8 , new Configuration() );
+
+    List<ColumnBinary> list = createSimpleCaseData();
+    tmpWriter.append( 10 , list );
+    tmpWriter.append( 10 , list );
+    int blockSize = tmpWriter.size();
+    tmpWriter.close();
+
+    byte[] header = "header".getBytes();
+
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( blockSize + header.length , new Configuration() );
+    writer.appendHeader( header );
+    writer.append( 10 , list );
+    assertTrue( writer.canAppend( list ) );
+    writer.append( 10 , list );
+    assertEquals( writer.size() , blockSize + header.length );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeVariableBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( blockSize + header.length , block.length );
+  }
+
+  @Test
+  public void T_blockSizeEqualsHeaderAppendBlockBinary_equals_withFixedBlock() throws IOException {
+    PushdownSupportedBlockWriter tmpWriter = new PushdownSupportedBlockWriter();
+    tmpWriter.setup( 1024 * 1024 * 8 , new Configuration() );
+
+    List<ColumnBinary> list = createSimpleCaseData();
+    tmpWriter.append( 10 , list );
+    tmpWriter.append( 10 , list );
+    int blockSize = tmpWriter.size();
+    tmpWriter.close();
+
+    byte[] header = "header".getBytes();
+
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( blockSize + header.length , new Configuration() );
+    writer.appendHeader( header );
+    writer.append( 10 , list );
+    assertTrue( writer.canAppend( list ) );
+    writer.append( 10 , list );
+    assertEquals( writer.size() , blockSize + header.length );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeFixedBlock( out );
+    byte[] block = out.toByteArray();
+    assertEquals( blockSize + header.length , block.length );
+  }
+
+  @Test
+  public void T_bufferOverflow_BlockSizeExceededAfterAddition() throws IOException {
+    PushdownSupportedBlockWriter tmpWriter = new PushdownSupportedBlockWriter();
+    tmpWriter.setup( 1024 * 1024 * 8 , new Configuration() );
+
+    List<ColumnBinary> list = createSimpleCaseData();
+    tmpWriter.append( 10 , list );
+    tmpWriter.append( 10 , list );
+    int blockSize = tmpWriter.size();
+    tmpWriter.close();
+
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( blockSize , new Configuration() );
+    writer.append( 10 , list );
+    assertTrue( writer.canAppend( list ) );
+    writer.append( 10 , list );
+    assertEquals( writer.size() , blockSize );
+    assertFalse( writer.canAppend( list ) );
+    assertThrows( IOException.class ,
+      () -> {
+        writer.append( 10 , list );
+      }
+    );
+  }
+
+  @Test
+  public void T_canAppend_throwsException_whenColumnBinaryTreeIsEmpty() throws IOException {
+    PushdownSupportedBlockWriter tmpWriter = new PushdownSupportedBlockWriter();
+    tmpWriter.setup( 1024 * 1024 * 8 , new Configuration() );
+
+    List<ColumnBinary> list = createSimpleCaseData();
+    tmpWriter.append( 10 , list );
+    int blockSize = tmpWriter.size();
+    tmpWriter.close();
+
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( blockSize - 1 , new Configuration() );
+    assertThrows( IOException.class ,
+      () -> {
+        writer.canAppend( list );
+      }
+    );
+  }
+
+  @Test
+  public void T_writeFixedBlock_throwsException_whenBlockSizeIsSmallAndMetaBinaryAfterCompressIsLargerThanOriginal() throws IOException {
+    // If the meta is small, the size after compression may be large.
+    // Because the block size is usually in MB units, the possibility of the meta becoming small is extremely low.
+    PushdownSupportedBlockWriter tmpWriter = new PushdownSupportedBlockWriter();
+    Configuration config = new Configuration();
+    config.set( "block.maker.compress.class" , BlockTestCompressor.class.getName() );
+    tmpWriter.setup( 1024 * 1024 * 8 , config );
+
+    List<ColumnBinary> list = createCompressMetaCaseData();
+    tmpWriter.append( 1 , list );
+    int blockSize = tmpWriter.size();
+    tmpWriter.close();
+
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( blockSize , config );
+    writer.canAppend( list );
+    writer.append( 1 , list );
+    assertEquals( writer.size() , blockSize );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    assertThrows( IOException.class ,
+      () -> {
+        writer.writeFixedBlock( out );
+      }
+    );
+    // This is invalid block.
+    byte[] block = out.toByteArray();
+    assertEquals( blockSize + 1 , block.length );
+  }
+
+  @Test
+  public void T_writeVariableBlock_throwsException_whenBlockSizeIsSmallAndMetaBinaryAfterCompressIsLargerThanOriginal() throws IOException {
+    // If the meta is small, the size after compression may be large.
+    // Because the block size is usually in MB units, the possibility of the meta becoming small is extremely low.
+    PushdownSupportedBlockWriter tmpWriter = new PushdownSupportedBlockWriter();
+    Configuration config = new Configuration();
+    config.set( "block.maker.compress.class" , BlockTestCompressor.class.getName() );
+    tmpWriter.setup( 1024 * 1024 * 8 , config );
+
+    List<ColumnBinary> list = createCompressMetaCaseData();
+    tmpWriter.append( 1 , list );
+    int blockSize = tmpWriter.size();
+    tmpWriter.close();
+
+    PushdownSupportedBlockWriter writer = new PushdownSupportedBlockWriter();
+    writer.setup( blockSize , config );
+    writer.canAppend( list );
+    writer.append( 1 , list );
+    assertEquals( writer.size() , blockSize );
+
+    int outputDataSize = writer.size();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    assertThrows( IOException.class ,
+      () -> {
+        writer.writeVariableBlock( out );
+      }
+    );
+    // This is invalid block.
+    byte[] block = out.toByteArray();
+    assertEquals( blockSize + 1 , block.length );
   }
 
 }

--- a/src/test/java/jp/co/yahoo/yosegi/blockindex/DummyBlockIndex.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blockindex/DummyBlockIndex.java
@@ -37,6 +37,11 @@ public class DummyBlockIndex implements IBlockIndex{
   }
 
   @Override
+  public IBlockIndex clone() {
+    return new DummyBlockIndex( canMerge );
+  }
+
+  @Override
   public BlockIndexType getBlockIndexType(){
     return BlockIndexType.UNSUPPORTED;
   }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
So far, we have made predictions for the block size to be created. I changed it to calculate this correctly.
This will prevent the exception due to a Buffer overflow.

### How did you do the test? (Not required for updating documents)
I checked whether the calculation of data size was correct with the setting of uncompressed metadata.
It was confirmed in the unit test that the data size after addition and the size after the addition match, and the size after addition and the block size written out the match.