### PR TITLE
Yosegi-65 It becomes an array of NULL when decoding Snappy.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/compressor/AbstractCommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/AbstractCommonsCompressor.java
@@ -33,7 +33,9 @@ public abstract class AbstractCommonsCompressor implements ICompressor {
   abstract InputStream createInputStream( final InputStream in ) throws IOException;
 
   abstract OutputStream createOutputStream(
-      final OutputStream out , final CompressResult compressResult ) throws IOException;
+      final OutputStream out ,
+      final long decompressSize,
+      final CompressResult compressResult ) throws IOException;
 
   @Override
   public byte[] compress(
@@ -42,7 +44,7 @@ public abstract class AbstractCommonsCompressor implements ICompressor {
       final int length ,
       final CompressResult compressResult ) throws IOException {
     ByteArrayOutputStream byteArrayOut = new ByteArrayOutputStream();
-    OutputStream out = createOutputStream( byteArrayOut , compressResult );
+    OutputStream out = createOutputStream( byteArrayOut , length , compressResult );
 
     out.write( data , start , length );
     out.close();

--- a/src/main/java/jp/co/yahoo/yosegi/compressor/BZip2CommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/BZip2CommonsCompressor.java
@@ -49,7 +49,9 @@ public class BZip2CommonsCompressor extends AbstractCommonsCompressor {
 
   @Override
   public OutputStream createOutputStream(
-      final OutputStream out , final CompressResult compressResult ) throws IOException {
+      final OutputStream out ,
+      final long decompressSize,
+      final CompressResult compressResult ) throws IOException {
     int level = getCompressLevel( compressResult.getCompressionPolicy() );
     int optLevel = compressResult.getCurrentLevel();
     if ( ( level - optLevel ) < BZip2CompressorOutputStream.MIN_BLOCKSIZE ) {

--- a/src/main/java/jp/co/yahoo/yosegi/compressor/CompressorNameShortCut.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/CompressorNameShortCut.java
@@ -31,7 +31,7 @@ public final class CompressorNameShortCut {
     CLASS_NAME_PAIR.set( "jp.co.yahoo.yosegi.compressor.DeflateCommonsCompressor" , "deflater" );
     CLASS_NAME_PAIR.set( "jp.co.yahoo.yosegi.compressor.BZip2CommonsCompressor" , "bzip2" );
     CLASS_NAME_PAIR.set( "jp.co.yahoo.yosegi.compressor.FramedLZ4CommonsCompressor" , "lz4" );
-    CLASS_NAME_PAIR.set( "jp.co.yahoo.yosegi.compressor.FramedSnappyCommonsCompressor" , "snappy" );
+    CLASS_NAME_PAIR.set( "jp.co.yahoo.yosegi.compressor.SnappyCommonsCompressor" , "snappy" );
     CLASS_NAME_PAIR.set( "jp.co.yahoo.yosegi.compressor.LzmaCommonsCompressor" , "lzma" );
     CLASS_NAME_PAIR.set( "jp.co.yahoo.yosegi.compressor.ZstdCommonsCompressor" , "zstd" );
   }

--- a/src/main/java/jp/co/yahoo/yosegi/compressor/DeflateCommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/DeflateCommonsCompressor.java
@@ -51,7 +51,9 @@ public class DeflateCommonsCompressor extends AbstractCommonsCompressor {
 
   @Override
   public OutputStream createOutputStream(
-      final OutputStream out , final CompressResult compressResult ) throws IOException {
+      final OutputStream out ,
+      final long decompressSize,
+      final CompressResult compressResult ) throws IOException {
     DeflateParameters op = new DeflateParameters();
     int level = getCompressLevel( compressResult.getCompressionPolicy() );
     int optLevel = compressResult.getCurrentLevel();

--- a/src/main/java/jp/co/yahoo/yosegi/compressor/FramedLZ4CommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/FramedLZ4CommonsCompressor.java
@@ -18,8 +18,8 @@
 
 package jp.co.yahoo.yosegi.compressor;
 
-import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
-import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream;
+import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream;
+import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorOutputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,13 +29,15 @@ public class FramedLZ4CommonsCompressor extends AbstractCommonsCompressor {
 
   @Override
   public InputStream createInputStream( final InputStream in ) throws IOException {
-    return new FramedLZ4CompressorInputStream( in );
+    return new BlockLZ4CompressorInputStream( in );
   }
 
   @Override
   public OutputStream createOutputStream(
-      final OutputStream out , final CompressResult compressResult ) throws IOException {
-    return new FramedLZ4CompressorOutputStream( out );
+      final OutputStream out ,
+      final long decompressSize,
+      final CompressResult compressResult ) throws IOException {
+    return new BlockLZ4CompressorOutputStream( out );
   }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/compressor/FramedLZ4CommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/FramedLZ4CommonsCompressor.java
@@ -18,8 +18,8 @@
 
 package jp.co.yahoo.yosegi.compressor;
 
-import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream;
-import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorOutputStream;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,7 +29,7 @@ public class FramedLZ4CommonsCompressor extends AbstractCommonsCompressor {
 
   @Override
   public InputStream createInputStream( final InputStream in ) throws IOException {
-    return new BlockLZ4CompressorInputStream( in );
+    return new FramedLZ4CompressorInputStream( in );
   }
 
   @Override
@@ -37,7 +37,7 @@ public class FramedLZ4CommonsCompressor extends AbstractCommonsCompressor {
       final OutputStream out ,
       final long decompressSize,
       final CompressResult compressResult ) throws IOException {
-    return new BlockLZ4CompressorOutputStream( out );
+    return new FramedLZ4CompressorOutputStream( out );
   }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/compressor/GzipCommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/GzipCommonsCompressor.java
@@ -51,7 +51,9 @@ public class GzipCommonsCompressor extends AbstractCommonsCompressor {
 
   @Override
   public OutputStream createOutputStream(
-      final OutputStream out , final CompressResult compressResult ) throws IOException {
+      final OutputStream out ,
+      final long decompressSize,
+      final CompressResult compressResult ) throws IOException {
     GzipParameters op = new GzipParameters();
     int level = getCompressLevel( compressResult.getCompressionPolicy() ); 
     int optLevel = compressResult.getCurrentLevel();

--- a/src/main/java/jp/co/yahoo/yosegi/compressor/LzmaCommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/LzmaCommonsCompressor.java
@@ -35,7 +35,9 @@ public class LzmaCommonsCompressor extends AbstractCommonsCompressor {
 
   @Override
   public OutputStream createOutputStream(
-      final OutputStream out , final CompressResult compressResult ) throws IOException {
+      final OutputStream out ,
+      final long decompressSize,
+      final CompressResult compressResult ) throws IOException {
     return new LZMACompressorOutputStream( out );
   }
 

--- a/src/main/java/jp/co/yahoo/yosegi/compressor/SnappyCommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/SnappyCommonsCompressor.java
@@ -18,24 +18,26 @@
 
 package jp.co.yahoo.yosegi.compressor;
 
-import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInputStream;
-import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorOutputStream;
+import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream;
+import org.apache.commons.compress.compressors.snappy.SnappyCompressorOutputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public class FramedSnappyCommonsCompressor extends AbstractCommonsCompressor {
+public class SnappyCommonsCompressor extends AbstractCommonsCompressor {
 
   @Override
   public InputStream createInputStream( final InputStream in ) throws IOException {
-    return new FramedSnappyCompressorInputStream( in );
+    return new SnappyCompressorInputStream( in );
   }
 
   @Override
   public OutputStream createOutputStream(
-      final OutputStream out , final CompressResult compressResult ) throws IOException {
-    return new FramedSnappyCompressorOutputStream( out );
+      final OutputStream out ,
+      final long decompressSize,
+      final CompressResult compressResult ) throws IOException {
+    return new SnappyCompressorOutputStream( out , decompressSize );
   }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/compressor/ZstdCommonsCompressor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/compressor/ZstdCommonsCompressor.java
@@ -34,7 +34,9 @@ public class ZstdCommonsCompressor extends AbstractCommonsCompressor {
 
   @Override
   public OutputStream createOutputStream(
-        final OutputStream out , final CompressResult compressResult ) throws IOException {
+      final OutputStream out ,
+      final long decompressSize,
+      final CompressResult compressResult ) throws IOException {
     return new ZstdCompressorOutputStream( out );
   }
 

--- a/src/test/java/jp/co/yahoo/yosegi/compressor/TestCompressor.java
+++ b/src/test/java/jp/co/yahoo/yosegi/compressor/TestCompressor.java
@@ -40,7 +40,7 @@ public class TestCompressor {
       DeflateCommonsCompressor.class.getName(),
       BZip2CommonsCompressor.class.getName(),
       DeflateCommonsCompressor.class.getName(),
-      FramedSnappyCommonsCompressor.class.getName(),
+      SnappyCommonsCompressor.class.getName(),
       FramedLZ4CommonsCompressor.class.getName(),
       ZstdCommonsCompressor.class.getName(),
     };


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
If the data size is large, it will be 0 bytes in the Framed class.
Although the data size is required when creating OutputStream, the class has been changed because decoding was confirmed even with large data size.

### How did you do the test? (Not required for updating documents)

I reproduced the data size in 2MB but failed in LZ4.
Implementation of unit test is implemented by ISSUE of LZ4.

https://yosegi.atlassian.net/browse/YOSEGI-66
