### PR TITLE
Yosegi-78 Removed premise tests where row-by-line filters are applied.

### DIFF
--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestGetPrimitiveObjectArray.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestGetPrimitiveObjectArray.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import jp.co.yahoo.yosegi.spread.column.filter.PerfectMatchStringFilter;
 import jp.co.yahoo.yosegi.spread.expression.*;
 
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
@@ -91,59 +90,6 @@ public class TestGetPrimitiveObjectArray{
   }
 
   @Test
-  public void T_2() throws IOException{
-    try(YosegiReader reader = new YosegiReader()){
-    Configuration readerConfig = new Configuration();
-    byte[] data = create();
-    InputStream fileIn = new ByteArrayInputStream( data );
-    reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ) {
-      IExpressionNode node = new AndExpressionNode();
-      node.addChildNode(new ExecuterNode(new StringExtractNode("key1"), new PerfectMatchStringFilter("a")));
-      Spread spread = reader.next();
-      IExpressionIndex indexList = IndexFactory.toExpressionIndex(spread, node.exec(spread));
-      IColumn key1Column = spread.getColumn("key1");
-      PrimitiveObject[] primitiveArray = key1Column.getPrimitiveObjectArray(indexList, 0, indexList.size());
-      assertEquals(4, primitiveArray.length);
-      assertEquals("a", primitiveArray[0].getString());
-      assertEquals("a", primitiveArray[1].getString());
-      assertEquals("a", primitiveArray[2].getString());
-      assertEquals("a", primitiveArray[3].getString());
-
-    }
-    }
-  }
-
-  @Test
-  public void T_3() throws IOException{
-    try(YosegiReader reader = new YosegiReader()) {
-      Configuration readerConfig = new Configuration();
-      readerConfig.set("spread.reader.expand.column", "{ \"base\" : { \"node\" : \"key2\" , \"link_name\" : \"expand_key2\" } }");
-      byte[] data = create();
-      InputStream fileIn = new ByteArrayInputStream(data);
-      reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        IExpressionNode node = new AndExpressionNode();
-        node.addChildNode(new ExecuterNode(new StringExtractNode("key1"), new PerfectMatchStringFilter("a")));
-        Spread spread = reader.next();
-        IExpressionIndex indexList = IndexFactory.toExpressionIndex(spread, node.exec(spread));
-        IColumn key1Column = spread.getColumn("expand_key2");
-        PrimitiveObject[] primitiveArray = key1Column.getPrimitiveObjectArray(indexList, 0, indexList.size());
-        assertEquals(9, primitiveArray.length);
-        assertEquals(1, primitiveArray[0].getInt());
-        assertEquals(2, primitiveArray[1].getInt());
-        assertEquals(3, primitiveArray[2].getInt());
-        assertEquals(6, primitiveArray[3].getInt());
-        assertEquals(7, primitiveArray[4].getInt());
-        assertEquals(8, primitiveArray[5].getInt());
-        assertEquals(13, primitiveArray[6].getInt());
-        assertEquals(14, primitiveArray[7].getInt());
-        assertEquals(15, primitiveArray[8].getInt());
-      }
-    }
-  }
-
-  @Test
   public void T_4() throws IOException{
     try(YosegiReader reader = new YosegiReader()) {
       Configuration readerConfig = new Configuration();
@@ -177,32 +123,4 @@ public class TestGetPrimitiveObjectArray{
     }
   }
 
-  @Test
-  public void T_5() throws IOException {
-    try (YosegiReader reader = new YosegiReader()) {
-      Configuration readerConfig = new Configuration();
-      readerConfig.set("spread.reader.expand.column", "{ \"base\" : { \"node\" : \"key2\" , \"link_name\" : \"expand_key2\" } }");
-      byte[] data = create();
-      InputStream fileIn = new ByteArrayInputStream(data);
-      reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        IExpressionNode node = new AndExpressionNode();
-        node.addChildNode(new ExecuterNode(new StringExtractNode("key1"), new PerfectMatchStringFilter("a")));
-        Spread spread = reader.next();
-        IExpressionIndex indexList = IndexFactory.toExpressionIndex(spread, node.exec(spread));
-        IColumn key1Column = spread.getColumn("key1");
-        PrimitiveObject[] primitiveArray = key1Column.getPrimitiveObjectArray(indexList, 0, indexList.size());
-        assertEquals(9, primitiveArray.length);
-        assertEquals("a", primitiveArray[0].getString());
-        assertEquals("a", primitiveArray[1].getString());
-        assertEquals("a", primitiveArray[2].getString());
-        assertEquals("a", primitiveArray[3].getString());
-        assertEquals("a", primitiveArray[4].getString());
-        assertEquals("a", primitiveArray[5].getString());
-        assertEquals("a", primitiveArray[6].getString());
-        assertEquals("a", primitiveArray[7].getString());
-        assertEquals("a", primitiveArray[8].getString());
-      }
-    }
-  }
 }

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestMultiArray.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestMultiArray.java
@@ -39,7 +39,6 @@ import jp.co.yahoo.yosegi.reader.YosegiReader;
 import jp.co.yahoo.yosegi.writer.YosegiRecordWriter;
 import jp.co.yahoo.yosegi.spread.Spread;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
-import jp.co.yahoo.yosegi.spread.column.filter.PerfectMatchStringFilter;
 import jp.co.yahoo.yosegi.spread.expression.*;
 
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
@@ -129,54 +128,6 @@ public class TestMultiArray{
         assertEquals(2, ((PrimitiveObject) (integerColumn.get(1).getRow())).getInt());
         assertEquals(3, ((PrimitiveObject) (integerColumn.get(2).getRow())).getInt());
         assertEquals(null, stringColumn.get(3).getRow());
-      }
-    }
-  }
-
-  @Test
-  public void T_4() throws IOException{
-    try(YosegiReader reader = new YosegiReader()) {
-      Configuration readerConfig = new Configuration();
-      readerConfig.set("spread.reader.expand.column", "{ \"base\" : { \"node\" : \"array1\" , \"link_name\" : \"expand_array1\", \"child_node\" : { \"node\" : \"array2\"  , \"link_name\" : \"expand_array2\"  } } }");
-      IExpressionNode node = new AndExpressionNode();
-      StringExtractNode array2Node = new StringExtractNode("array2-string");
-      node.addChildNode(new ExecuterNode(new StringExtractNode("expand_array2", array2Node), new PerfectMatchStringFilter("a")));
-      byte[] data = out.toByteArray();
-      InputStream fileIn = new ByteArrayInputStream(data);
-      reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
-        IColumn spreadColumn = spread.getColumn("expand_array2");
-        assertEquals(spreadColumn.getColumnType(), ColumnType.SPREAD);
-        IColumn stringColumn = spreadColumn.getColumn("array2-string");
-        IExpressionIndex indexList = IndexFactory.toExpressionIndex(spread, node.exec(spread));
-        assertEquals(1, indexList.size());
-
-        assertEquals("a", ((PrimitiveObject) (stringColumn.get(indexList.get(0)).getRow())).getString());
-      }
-    }
-  }
-
-  @Test
-  public void T_5() throws IOException{
-    try(YosegiReader reader = new YosegiReader()) {
-      Configuration readerConfig = new Configuration();
-      readerConfig.set("spread.reader.expand.column", "{ \"base\" : { \"node\" : \"array1\" , \"link_name\" : \"expand_array1\", \"child_node\" : { \"node\" : \"array2\"  , \"link_name\" : \"expand_array2\"  } } }");
-      readerConfig.set("spread.reader.flatten.column", "[ { \"link_name\" : \"string\" , \"nodes\" : [\"expand_array2\" , \"array2-string\"] } , { \"link_name\" : \"integer\" , \"nodes\" : [\"expand_array2\" , \"array2-integer\"] } ]");
-      IExpressionNode node = new AndExpressionNode();
-      node.addChildNode(new ExecuterNode(new StringExtractNode("string"), new PerfectMatchStringFilter("b")));
-      byte[] data = out.toByteArray();
-      InputStream fileIn = new ByteArrayInputStream(data);
-      reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
-        IColumn stringColumn = spread.getColumn("string");
-        IColumn integerColumn = spread.getColumn("integer");
-        IExpressionIndex indexList = IndexFactory.toExpressionIndex(spread, node.exec(spread));
-        assertEquals(1, indexList.size());
-
-        assertEquals("b", ((PrimitiveObject) (stringColumn.get(indexList.get(0)).getRow())).getString());
-        assertEquals(2, ((PrimitiveObject) (integerColumn.get(indexList.get(0)).getRow())).getInt());
       }
     }
   }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Unit tests fail for encodings that do not support row filters.
Removed test cases that are predicated on being filtered.

### How did you do the test? (Not required for updating documents)
