### PR TITLE
Yosegi-89 Addition of interface to skip load processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <groupId>jp.co.yahoo.yosegi</groupId>
   <artifactId>yosegi</artifactId>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <packaging>jar</packaging>
   <name>Yosegi</name>
   <description>Yosegi package.</description>

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/DumpSpreadColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/DumpSpreadColumnBinaryMaker.java
@@ -128,6 +128,9 @@ public class DumpSpreadColumnBinaryMaker implements IColumnBinaryMaker {
       IColumnBinaryMaker maker = FindColumnBinaryMaker.get( childColumnBinary.makerClassName );
       IMemoryAllocator childAllocator =
           allocator.getChild( childColumnBinary.columnName , childColumnBinary.columnType );
+      if ( childAllocator.isLoadingSkipped() ) {
+        continue;
+      }
       maker.loadInMemoryStorage( childColumnBinary , childAllocator );
       if ( maxValueCount < childAllocator.getValueCount() ) {
         maxValueCount = childAllocator.getValueCount();

--- a/src/main/java/jp/co/yahoo/yosegi/inmemory/IMemoryAllocator.java
+++ b/src/main/java/jp/co/yahoo/yosegi/inmemory/IMemoryAllocator.java
@@ -125,4 +125,19 @@ public interface IMemoryAllocator {
     setPrimitiveObject( index , dic.getPrimitiveObject( dicIndex ) );
   }
 
+  /**
+   * This interface is used by Row Type to determine if a child column needs to be loaded.
+   * In the load process of Row Type, load can be skipped
+   * if the child IMemoryAllocator returns true.
+   * However, whether to skip load depends on the implementation of IColumnBinary.
+   * Therefore, this method is not meant to guarantee skipping.
+   * Regardless of this method, set method should be implemented so
+   * that it is NULL for columns that do not need to be processed.
+   *
+   * @return Whether load can be skipped
+   */
+  default boolean isLoadingSkipped() {
+    return false;
+  } 
+
 }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

The query engine defines a specific column in Row Type.
When there is a column that is not defined in Row Type in the file, I want to skip load process.
However, there is no interface to notify that the load process is unnecessary.
Add an interface to skip unnecessary load on Row Type on Yosegi side.

### How did you do the test? (Not required for updating documents)

The existing unit tests have passed.
The default handling of the interface does not allow skipping.


