### PR TITLE
Bug fix on NULL filter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <groupId>jp.co.yahoo.yosegi</groupId>
   <artifactId>yosegi</artifactId>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <packaging>jar</packaging>
   <name>Yosegi</name>
   <description>Yosegi package.</description>

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/BufferDirectDictionaryLinkCellManager.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/BufferDirectDictionaryLinkCellManager.java
@@ -101,33 +101,8 @@ public class BufferDirectDictionaryLinkCellManager implements IDictionaryCellMan
       final boolean[] filterArray ) throws IOException {
     switch ( filter.getFilterType() ) {
       case NOT_NULL:
-        if ( columnType != ( (INullFilter)filter ).getTargetColumnType() ) {
-          return null;
-        }
-        for ( int i = 0 ; i < filterArray.length ; i++ ) {
-          if ( i < size() ) {
-            if ( dicIndexIntBuffer.get(i) != 0 ) {
-              filterArray[i] = true;
-            }
-          } else {
-            filterArray[i] = false;
-          }
-        }
-        return filterArray;
       case NULL:
-        if ( columnType != ( (INullFilter)filter ).getTargetColumnType() ) {
-          return null;
-        }
-        for ( int i = 0 ; i < filterArray.length ; i++ ) {
-          if ( i < size() ) {
-            if ( dicIndexIntBuffer.get(i) == 0 ) {
-              filterArray[i] = true;
-            }
-          } else {
-            filterArray[i] = true;
-          }
-        }
-        return filterArray;
+        return null;
       default:
         return index.filter( filter , filterArray );
     }

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/ConstantColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/ConstantColumnBinaryMaker.java
@@ -342,12 +342,8 @@ public class ConstantColumnBinaryMaker implements IColumnBinaryMaker {
         final IFilter filter , final boolean[] filterArray ) throws IOException {
       switch ( filter.getFilterType() ) {
         case NOT_NULL:
-          return null;
         case NULL:
-          if ( columnType != ( (INullFilter)filter ).getTargetColumnType() ) {
-            return null;
-          }
-          return new boolean[filterArray.length];
+          return null;
         default:
           return index.filter( filter , filterArray );
       }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
There is a bug that gives incorrect results when the column and the total number of rows do not match in the NULL filter.
Since the current filter cannot get the total number of rows, I fixed it by removing the processing of NULL filter.

### How did you do the test? (Not required for updating documents)
