### PR TITLE
Yosegi-94 Upgrade jacoco to 0.8.6 to support JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.6</version>
         <executions>
           <execution>
             <id>jacoco-initialize</id>

--- a/src/test/java/jp/co/yahoo/yosegi/util/TestIndexAndObject.java
+++ b/src/test/java/jp/co/yahoo/yosegi/util/TestIndexAndObject.java
@@ -89,7 +89,7 @@ public class TestIndexAndObject {
   public void T_addAndGet_throwsExeption_withSmallerThanStartIndex(){
     IndexAndObject<String> indexAndObj = new IndexAndObject<String>( 5 );
     indexAndObj.add( "test0" );
-    assertThrows( ArrayIndexOutOfBoundsException.class ,
+    assertThrows( IndexOutOfBoundsException.class ,
       () -> {
         indexAndObj.get(4);
       }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

Upgrade jacoco from 0.8.0 to 0.8.6 (the latest version as of now).
https://www.jacoco.org/jacoco/trunk/doc/changes.html

JIRA: https://yosegi.atlassian.net/browse/YOSEGI-94

### How did you do the test? (Not required for updating documents)
I ran "mvn test" with AdoptOpenJDK 11.0.9.

```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestIndexAndObject.T_addAndGet_throwsExeption_withSmallerThanStartIndex:92 Unexpected exception type thrown ==> expected: <java.lang.ArrayIndexOutOfBoundsException> but was: <java.lang.IndexOutOfBoundsException>
[INFO] 
[ERROR] Tests run: 8532, Failures: 1, Errors: 0, Skipped: 0
```

The above failure can be fixed in a separate issue.