### PR TITLE
Deprecate YosegiReader.next method

### DIFF
--- a/src/test/java/jp/co/yahoo/yosegi/binary/TestColumnBinaryTree.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/TestColumnBinaryTree.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
 import org.junit.jupiter.api.Test;
 
 import jp.co.yahoo.yosegi.config.Configuration;
@@ -52,8 +53,9 @@ public class TestColumnBinaryTree{
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
     int line = 0;
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       line += spread.size();
     }
     assertEquals( 1 , line );
@@ -61,8 +63,9 @@ public class TestColumnBinaryTree{
     fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
     line = 0;
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       line += spread.size();
     }
     assertEquals( 1 , line );

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestBooleanBlockIndex.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestBooleanBlockIndex.java
@@ -16,9 +16,11 @@
 package jp.co.yahoo.yosegi.blackbox;
 
 import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 import jp.co.yahoo.yosegi.message.parser.IParser;
 import jp.co.yahoo.yosegi.message.parser.json.JacksonMessageReader;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import jp.co.yahoo.yosegi.reader.YosegiReader;
 import jp.co.yahoo.yosegi.spread.Spread;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
@@ -144,8 +146,9 @@ public class TestBooleanBlockIndex {
       byte[] data = getData();
       InputStream in = new ByteArrayInputStream(data);
       reader.setNewStream(in, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         for (List<Object> expected : expecteds) {
           String columnName = (String) expected.get(0);
           IColumn col = spread.getColumn(columnName);
@@ -315,8 +318,9 @@ public class TestBooleanBlockIndex {
       InputStream in = new ByteArrayInputStream(data);
       reader.setBlockSkipIndex(index);
       reader.setNewStream(in, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         for (List<Object> expected : expecteds) {
           String columnName = (String) expected.get(0);
           IColumn col = spread.getColumn(columnName);
@@ -566,8 +570,9 @@ public class TestBooleanBlockIndex {
       InputStream in = new ByteArrayInputStream(data);
       reader.setBlockSkipIndex(index);
       reader.setNewStream(in, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         for (List<Object> expected : expecteds) {
           String columnName = (String) expected.get(0);
           IColumn col = spread.getColumn(columnName);
@@ -735,8 +740,9 @@ public class TestBooleanBlockIndex {
       InputStream in = new ByteArrayInputStream(data);
       reader.setBlockSkipIndex(index);
       reader.setNewStream(in, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         for (List<Object> expected : expecteds) {
           String colName = (String) expected.get(0);
           IColumn col = spread.getColumn(colName);

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestEmptyArray.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestEmptyArray.java
@@ -25,6 +25,8 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -83,8 +85,9 @@ public class TestEmptyArray{
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn unionColumn = spread.getColumn("array1");
         assertEquals(unionColumn.getColumnType(), ColumnType.ARRAY);
         assertEquals(unionColumn.size(), 1);
@@ -118,8 +121,9 @@ public class TestEmptyArray{
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         assertEquals(4, spread.size());
         IColumn spreadColumn = spread.getColumn("expand_array1");
         assertEquals(spreadColumn.getColumnType(), ColumnType.SPREAD);

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestExpandAndFlatten.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestExpandAndFlatten.java
@@ -25,6 +25,8 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -74,8 +76,9 @@ public class TestExpandAndFlatten{
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn f1Column = spread.getColumn("f1");
         IColumn f2Column = spread.getColumn("f2");
         IColumn f3Column = spread.getColumn("f3");

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestMultiArray.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestMultiArray.java
@@ -26,6 +26,8 @@ import java.io.InputStreamReader;
 
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -74,8 +76,9 @@ public class TestMultiArray{
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn unionColumn = spread.getColumn("array1");
         assertEquals(unionColumn.getColumnType(), ColumnType.ARRAY);
       }
@@ -90,8 +93,9 @@ public class TestMultiArray{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream(data);
     reader.setNewStream(fileIn, data.length, readerConfig);
-    while (reader.hasNext()) {
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn spreadColumn = spread.getColumn("expand_array2");
       assertEquals(spreadColumn.getColumnType(), ColumnType.SPREAD);
       IColumn stringColumn = spreadColumn.getColumn("array2-string");
@@ -113,8 +117,9 @@ public class TestMultiArray{
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn stringColumn = spread.getColumn("string");
         assertEquals(3, stringColumn.size());
         IColumn integerColumn = spread.getColumn("integer");
@@ -140,8 +145,9 @@ public class TestMultiArray{
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn stringColumn = spread.getColumn("expand_array3");
         assertEquals(3, stringColumn.size());
 

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestPrimitiveSchema.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestPrimitiveSchema.java
@@ -27,6 +27,8 @@ import java.io.ByteArrayOutputStream;
 
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -85,8 +87,9 @@ public class TestPrimitiveSchema{
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn column = spread.getColumn("d");
         System.err.println(column.toString());
         assertEquals(column.getColumnType(), ColumnType.BOOLEAN);

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestUnionSchema.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestUnionSchema.java
@@ -29,6 +29,8 @@ import java.io.InputStreamReader;
 
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -74,8 +76,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       System.out.println( spread.toString() );
     }
 
@@ -102,8 +105,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn unionColumn = spread.getColumn( "union" );
       assertEquals( unionColumn.getColumnType() , ColumnType.UNION );
     }
@@ -132,8 +136,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn unionColumn = spread.getColumn( "array_from_union" );
       IColumn key1Column = unionColumn.getColumn( "key1" );
       assertEquals( unionColumn.getColumnType() , ColumnType.SPREAD );
@@ -168,8 +173,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "union_in_array" );
       assertEquals( arrayColumn.getColumnType() , ColumnType.INTEGER );
       assertEquals( 4 , arrayColumn.size() );
@@ -203,8 +209,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "parallel" );
       assertEquals( arrayColumn.getColumnType() , ColumnType.BOOLEAN );
       assertEquals( 4 , arrayColumn.size() );
@@ -239,8 +246,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "k1" );
       assertEquals( arrayColumn.getColumnType() , ColumnType.STRING );
       assertEquals( 4 , arrayColumn.size() );
@@ -274,8 +282,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "other" );
       assertEquals( arrayColumn.getColumnType() , ColumnType.UNION );
       assertEquals( 8 , arrayColumn.size() );
@@ -317,8 +326,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "other" );
 
       assertEquals( "a" , ( (PrimitiveObject)( arrayColumn.get( 0 ).getRow() ) ).getString() );
@@ -347,8 +357,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.SHORT );
     }
@@ -378,8 +389,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.INTEGER );
     }
@@ -411,8 +423,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.LONG );
     }
@@ -446,8 +459,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }
@@ -481,8 +495,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }
@@ -510,8 +525,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.DOUBLE );
     }
@@ -541,8 +557,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }
@@ -572,8 +589,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }
@@ -601,8 +619,9 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }

--- a/src/test/java/jp/co/yahoo/yosegi/spread/flatten/TestFlatten.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/flatten/TestFlatten.java
@@ -18,6 +18,7 @@
 package jp.co.yahoo.yosegi.spread.flatten;
 
 import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
 import jp.co.yahoo.yosegi.spread.Spread;
 import jp.co.yahoo.yosegi.message.objects.*;
 import jp.co.yahoo.yosegi.reader.*;
@@ -61,8 +62,8 @@ public class TestFlatten {
     ByteArrayInputStream in = new ByteArrayInputStream( data );
     YosegiReader reader = new YosegiReader();
     reader.setNewStream( in , data.length , readerConfig );
-    
-    return reader.next();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<Spread>(reader, new SpreadRawConverter());
+    return spreadWrapReader.next();
   }
 
   @Test


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

Deprecate YosegiReader.next method.

### How did you do the test? (Not required for updating documents)

Replace YosegiReader into WrapReader in unit tests.