### PR TITLE
Deprecate YosegiReader.next method

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/reader/YosegiSchemaReader.java
+++ b/src/main/java/jp/co/yahoo/yosegi/reader/YosegiSchemaReader.java
@@ -19,6 +19,7 @@
 package jp.co.yahoo.yosegi.reader;
 
 import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
 import jp.co.yahoo.yosegi.message.parser.IParser;
 import jp.co.yahoo.yosegi.message.parser.ISettableIndexParser;
 import jp.co.yahoo.yosegi.message.parser.IStreamReader;
@@ -35,6 +36,8 @@ public class YosegiSchemaReader implements IStreamReader {
 
   private final YosegiReader currentReader = new YosegiReader();
   private final SpreadColumn spreadColumn = new SpreadColumn( "root" );
+  private final WrapReader<Spread> spreadWrapReader =
+      new WrapReader<>(currentReader, new SpreadRawConverter());
 
   private ISettableIndexParser currentParser;
   private IExpressionNode node = new AndExpressionNode();
@@ -71,12 +74,12 @@ public class YosegiSchemaReader implements IStreamReader {
   }
 
   private boolean nextReader() throws IOException {
-    if ( ! currentReader.hasNext() ) {
+    if (! spreadWrapReader.hasNext()) {
       currentSpread = null;
       currentIndex = 0;
       return false;
     }
-    currentSpread = currentReader.next();
+    currentSpread = spreadWrapReader.next();
     if ( currentSpread.size() == 0 ) {
       return nextReader();
     }
@@ -112,7 +115,7 @@ public class YosegiSchemaReader implements IStreamReader {
 
   @Override
   public void close() throws IOException {
-    currentReader.close();
+    spreadWrapReader.close();
   }
 
 }

--- a/src/test/java/jp/co/yahoo/yosegi/binary/TestColumnBinaryTree.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/TestColumnBinaryTree.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
 import org.junit.jupiter.api.Test;
 
 import jp.co.yahoo.yosegi.config.Configuration;
@@ -47,13 +48,14 @@ public class TestColumnBinaryTree{
     writer.close();
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
     int line = 0;
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       line += spread.size();
     }
     assertEquals( 1 , line );
@@ -61,8 +63,8 @@ public class TestColumnBinaryTree{
     fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
     line = 0;
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       line += spread.size();
     }
     assertEquals( 1 , line );

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestBooleanBlockIndex.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestBooleanBlockIndex.java
@@ -16,9 +16,11 @@
 package jp.co.yahoo.yosegi.blackbox;
 
 import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 import jp.co.yahoo.yosegi.message.parser.IParser;
 import jp.co.yahoo.yosegi.message.parser.json.JacksonMessageReader;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import jp.co.yahoo.yosegi.reader.YosegiReader;
 import jp.co.yahoo.yosegi.spread.Spread;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
@@ -140,12 +142,13 @@ public class TestBooleanBlockIndex {
   @MethodSource("D_blackbox_1")
   public void T_blackbox_1(final List<List<Object>> expecteds) throws IOException {
     try (YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       Configuration readerConfig = new Configuration();
       byte[] data = getData();
       InputStream in = new ByteArrayInputStream(data);
       reader.setNewStream(in, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         for (List<Object> expected : expecteds) {
           String columnName = (String) expected.get(0);
           IColumn col = spread.getColumn(columnName);
@@ -305,6 +308,7 @@ public class TestBooleanBlockIndex {
       List<List<Object>> expecteds)
       throws IOException {
     try (YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       IExpressionNode index = new AndExpressionNode();
       index.addChildNode(
           new ExecuterNode(new StringExtractNode(columnName1), new BooleanFilter(filterValue1)));
@@ -315,8 +319,8 @@ public class TestBooleanBlockIndex {
       InputStream in = new ByteArrayInputStream(data);
       reader.setBlockSkipIndex(index);
       reader.setNewStream(in, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         for (List<Object> expected : expecteds) {
           String columnName = (String) expected.get(0);
           IColumn col = spread.getColumn(columnName);
@@ -556,6 +560,7 @@ public class TestBooleanBlockIndex {
       List<List<Object>> expecteds)
       throws IOException {
     try (YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       IExpressionNode index = new OrExpressionNode();
       index.addChildNode(
           new ExecuterNode(new StringExtractNode(columnName1), new BooleanFilter(filterValue1)));
@@ -566,8 +571,8 @@ public class TestBooleanBlockIndex {
       InputStream in = new ByteArrayInputStream(data);
       reader.setBlockSkipIndex(index);
       reader.setNewStream(in, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         for (List<Object> expected : expecteds) {
           String columnName = (String) expected.get(0);
           IColumn col = spread.getColumn(columnName);
@@ -727,6 +732,7 @@ public class TestBooleanBlockIndex {
       final String columnName, final Boolean filterValue, List<List<Object>> expecteds)
       throws IOException {
     try (YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       IExpressionNode index = new NotExpressionNode();
       index.addChildNode(
           new ExecuterNode(new StringExtractNode(columnName), new BooleanFilter(filterValue)));
@@ -735,8 +741,8 @@ public class TestBooleanBlockIndex {
       InputStream in = new ByteArrayInputStream(data);
       reader.setBlockSkipIndex(index);
       reader.setNewStream(in, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         for (List<Object> expected : expecteds) {
           String colName = (String) expected.get(0);
           IColumn col = spread.getColumn(colName);

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestEmptyArray.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestEmptyArray.java
@@ -25,6 +25,8 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -79,12 +81,13 @@ public class TestEmptyArray{
     assertEquals( writeSpreadColumn.size() , 2 );
 
     try(YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       Configuration readerConfig = new Configuration();
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn unionColumn = spread.getColumn("array1");
         assertEquals(unionColumn.getColumnType(), ColumnType.ARRAY);
         assertEquals(unionColumn.size(), 1);
@@ -113,13 +116,14 @@ public class TestEmptyArray{
     }
 
     try(YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       Configuration readerConfig = new Configuration();
       readerConfig.set("spread.reader.expand.column", "{ \"base\" : { \"node\" : \"array1\" , \"link_name\" : \"expand_array1\" } }");
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         assertEquals(4, spread.size());
         IColumn spreadColumn = spread.getColumn("expand_array1");
         assertEquals(spreadColumn.getColumnType(), ColumnType.SPREAD);

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestExpandAndFlatten.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestExpandAndFlatten.java
@@ -25,6 +25,8 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -67,6 +69,7 @@ public class TestExpandAndFlatten{
     }
 
     try (YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       Configuration readerConfig = new Configuration();
       readerConfig.set("spread.reader.expand.column", "{ \"base\" :{ \"node\" : \"col3\" ,  \"link_name\" : \"expand\" } }");
       readerConfig.set("spread.reader.flatten.column", "[ { \"link_name\" : \"f1\" , \"nodes\" : [\"expand\" , \"f1\"] } , { \"link_name\" : \"f2\" , \"nodes\" : [\"expand\" , \"f2\"] } ]");
@@ -74,8 +77,8 @@ public class TestExpandAndFlatten{
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn f1Column = spread.getColumn("f1");
         IColumn f2Column = spread.getColumn("f2");
         IColumn f3Column = spread.getColumn("f3");

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestMultiArray.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestMultiArray.java
@@ -26,6 +26,8 @@ import java.io.InputStreamReader;
 
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -70,12 +72,13 @@ public class TestMultiArray{
   @Test
   public void T_1() throws IOException{
     try(YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       Configuration readerConfig = new Configuration();
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn unionColumn = spread.getColumn("array1");
         assertEquals(unionColumn.getColumnType(), ColumnType.ARRAY);
       }
@@ -85,13 +88,14 @@ public class TestMultiArray{
   @Test
   public void T_2() throws IOException{
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     readerConfig.set("spread.reader.expand.column", "{ \"base\" : { \"node\" : \"array1\" , \"link_name\" : \"expand_array1\", \"child_node\" : { \"node\" : \"array2\"  , \"link_name\" : \"expand_array2\"  } } }");
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream(data);
     reader.setNewStream(fileIn, data.length, readerConfig);
-    while (reader.hasNext()) {
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn spreadColumn = spread.getColumn("expand_array2");
       assertEquals(spreadColumn.getColumnType(), ColumnType.SPREAD);
       IColumn stringColumn = spreadColumn.getColumn("array2-string");
@@ -107,14 +111,15 @@ public class TestMultiArray{
   @Test
   public void T_3() throws IOException{
     try(YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       Configuration readerConfig = new Configuration();
       readerConfig.set("spread.reader.expand.column", "{ \"base\" : { \"node\" : \"array1\" , \"link_name\" : \"expand_array1\", \"child_node\" : { \"node\" : \"array2\"  , \"link_name\" : \"expand_array2\"  } } }");
       readerConfig.set("spread.reader.flatten.column", "[ { \"link_name\" : \"string\" , \"nodes\" : [\"expand_array2\" , \"array2-string\"] } , { \"link_name\" : \"integer\" , \"nodes\" : [\"expand_array2\" , \"array2-integer\"] } ]");
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn stringColumn = spread.getColumn("string");
         assertEquals(3, stringColumn.size());
         IColumn integerColumn = spread.getColumn("integer");
@@ -135,13 +140,14 @@ public class TestMultiArray{
   @Test
   public void T_6() throws IOException{
     try(YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       Configuration readerConfig = new Configuration();
       readerConfig.set("spread.reader.expand.column", "{ \"base\" : { \"node\" : \"array1\" , \"link_name\" : \"expand_array1\", \"child_node\" : { \"node\" : \"spread\"  , \"child_node\" : { \"node\" : \"array2\"  ,  \"link_name\" : \"expand_array2\" , \"child_node\" : { \"node\" : \"array3\"  ,  \"link_name\" : \"expand_array3\" }  }  } } }");
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn stringColumn = spread.getColumn("expand_array3");
         assertEquals(3, stringColumn.size());
 

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestPrimitiveSchema.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestPrimitiveSchema.java
@@ -27,6 +27,8 @@ import java.io.ByteArrayOutputStream;
 
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -81,12 +83,13 @@ public class TestPrimitiveSchema{
     assertEquals(s.getColumn("d").getColumnType(), ColumnType.BOOLEAN);
 
     try (YosegiReader reader = new YosegiReader()) {
+      WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
       Configuration readerConfig = new Configuration();
       byte[] data = out.toByteArray();
       InputStream fileIn = new ByteArrayInputStream(data);
       reader.setNewStream(fileIn, data.length, readerConfig);
-      while (reader.hasNext()) {
-        Spread spread = reader.next();
+      while (spreadWrapReader.hasNext()) {
+        Spread spread = spreadWrapReader.next();
         IColumn column = spread.getColumn("d");
         System.err.println(column.toString());
         assertEquals(column.getColumnType(), ColumnType.BOOLEAN);

--- a/src/test/java/jp/co/yahoo/yosegi/blackbox/TestUnionSchema.java
+++ b/src/test/java/jp/co/yahoo/yosegi/blackbox/TestUnionSchema.java
@@ -29,6 +29,8 @@ import java.io.InputStreamReader;
 
 import java.util.stream.Stream;
 
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
+import jp.co.yahoo.yosegi.reader.WrapReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -70,12 +72,13 @@ public class TestUnionSchema{
     writer.close();
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       System.out.println( spread.toString() );
     }
 
@@ -98,12 +101,13 @@ public class TestUnionSchema{
     writer.close();
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn unionColumn = spread.getColumn( "union" );
       assertEquals( unionColumn.getColumnType() , ColumnType.UNION );
     }
@@ -127,13 +131,14 @@ public class TestUnionSchema{
     writer.close();
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     readerConfig.set( "spread.reader.expand.column" , "{ \"base\" : { \"node\" : \"union\" , \"link_name\" : \"array_from_union\" } }" );
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn unionColumn = spread.getColumn( "array_from_union" );
       IColumn key1Column = unionColumn.getColumn( "key1" );
       assertEquals( unionColumn.getColumnType() , ColumnType.SPREAD );
@@ -163,13 +168,14 @@ public class TestUnionSchema{
     writer.close();
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     readerConfig.set( "spread.reader.expand.column" , "{ \"base\" : { \"node\" : \"union\" , \"link_name\" : \"array_from_union\" , \"child_node\" : { \"node\" : \"union_in_array\"  , \"link_name\" : \"union_in_array\" } } } }" );
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "union_in_array" );
       assertEquals( arrayColumn.getColumnType() , ColumnType.INTEGER );
       assertEquals( 4 , arrayColumn.size() );
@@ -198,13 +204,14 @@ public class TestUnionSchema{
     writer.close();
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     readerConfig.set( "spread.reader.expand.column" , "{ \"base\" : { \"node\" : \"union\" , \"child_node\" : { \"node\" : \"array\"  , \"link_name\" : \"array\"  } } , \"parallel\" : [ { \"link_name\" : \"parallel\" , \"base_link_name\" : \"array\" , \"nodes\" : [ \"union\" , \"array_parallel\" ] } ] }" );
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "parallel" );
       assertEquals( arrayColumn.getColumnType() , ColumnType.BOOLEAN );
       assertEquals( 4 , arrayColumn.size() );
@@ -233,14 +240,15 @@ public class TestUnionSchema{
     writer.close();
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     readerConfig.set( "spread.reader.expand.column" , "{ \"base\" : { \"node\" : \"union\" , \"child_node\" : { \"node\" : \"array\"  , \"link_name\" : \"array\"  } } , \"parallel\" : [ { \"link_name\" : \"parallel\" , \"base_link_name\" : \"array\" , \"nodes\" : [ \"union\" , \"array_parallel\" ] } ] }" );
     readerConfig.set( "spread.reader.flatten.column" , "[ { \"link_name\" : \"k1\" , \"nodes\" : [\"array\" , \"key1\"] } ]" );
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "k1" );
       assertEquals( arrayColumn.getColumnType() , ColumnType.STRING );
       assertEquals( 4 , arrayColumn.size() );
@@ -269,13 +277,14 @@ public class TestUnionSchema{
     writer.close();
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     readerConfig.set( "spread.reader.flatten.column" , "[ { \"link_name\" : \"other\" , \"nodes\" : [\"union\" , \"union_other\"] } ]" );
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "other" );
       assertEquals( arrayColumn.getColumnType() , ColumnType.UNION );
       assertEquals( 8 , arrayColumn.size() );
@@ -308,6 +317,7 @@ public class TestUnionSchema{
     writer.close();
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     readerConfig.set( "spread.reader.flatten.column" , "[ { \"link_name\" : \"other\" , \"nodes\" : [\"union\" , \"union_other\"] } ]" );
 
@@ -317,8 +327,8 @@ public class TestUnionSchema{
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn arrayColumn = spread.getColumn( "other" );
 
       assertEquals( "a" , ( (PrimitiveObject)( arrayColumn.get( 0 ).getRow() ) ).getString() );
@@ -343,12 +353,13 @@ public class TestUnionSchema{
     assertEquals( s.getColumn("d").getColumnType() , ColumnType.UNION );
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.SHORT );
     }
@@ -374,12 +385,13 @@ public class TestUnionSchema{
     assertEquals( s.getColumn("d").getColumnType() , ColumnType.UNION );
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.INTEGER );
     }
@@ -407,12 +419,13 @@ public class TestUnionSchema{
     assertEquals( s.getColumn("d").getColumnType() , ColumnType.UNION );
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.LONG );
     }
@@ -442,12 +455,13 @@ public class TestUnionSchema{
     assertEquals( s.getColumn("d").getColumnType() , ColumnType.UNION );
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }
@@ -477,12 +491,13 @@ public class TestUnionSchema{
     assertEquals( s.getColumn("d").getColumnType() , ColumnType.UNION );
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }
@@ -506,12 +521,13 @@ public class TestUnionSchema{
     assertEquals( s.getColumn("d").getColumnType() , ColumnType.UNION );
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.DOUBLE );
     }
@@ -537,12 +553,13 @@ public class TestUnionSchema{
     assertEquals( s.getColumn("d").getColumnType() , ColumnType.UNION );
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }
@@ -568,12 +585,13 @@ public class TestUnionSchema{
     assertEquals( s.getColumn("d").getColumnType() , ColumnType.UNION );
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }
@@ -597,12 +615,13 @@ public class TestUnionSchema{
     assertEquals( s.getColumn("d").getColumnType() , ColumnType.UNION );
 
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     Configuration readerConfig = new Configuration();
     byte[] data = out.toByteArray();
     InputStream fileIn = new ByteArrayInputStream( data );
     reader.setNewStream( fileIn , data.length , readerConfig );
-    while( reader.hasNext() ){
-      Spread spread = reader.next();
+    while (spreadWrapReader.hasNext()) {
+      Spread spread = spreadWrapReader.next();
       IColumn column = spread.getColumn( "d" );
       assertEquals( column.getColumnType() , ColumnType.UNION );
     }

--- a/src/test/java/jp/co/yahoo/yosegi/spread/flatten/TestFlatten.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/flatten/TestFlatten.java
@@ -18,6 +18,7 @@
 package jp.co.yahoo.yosegi.spread.flatten;
 
 import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.inmemory.SpreadRawConverter;
 import jp.co.yahoo.yosegi.spread.Spread;
 import jp.co.yahoo.yosegi.message.objects.*;
 import jp.co.yahoo.yosegi.reader.*;
@@ -60,9 +61,9 @@ public class TestFlatten {
 
     ByteArrayInputStream in = new ByteArrayInputStream( data );
     YosegiReader reader = new YosegiReader();
+    WrapReader<Spread> spreadWrapReader = new WrapReader<>(reader, new SpreadRawConverter());
     reader.setNewStream( in , data.length , readerConfig );
-    
-    return reader.next();
+    return spreadWrapReader.next();
   }
 
   @Test


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

Deprecate YosegiReader.next method.

### How did you do the test? (Not required for updating documents)

Replace YosegiReader into WrapReader in unit tests.
