### PR TITLE
Potential security vulnerability in the zstd C library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
-      <version>1.3.3-3</version>
+      <version>1.4.9-1</version>
       <optional>true</optional>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
Hi, @koijima , @yohto , I'd like to report a vulnerability issue in **jp.co.yahoo.yosegi:yosegi:2.0.1**.
### Issue Description
I noticed that **jp.co.yahoo.yosegi:yosegi:2.0.1** directly depends on **com.github.luben:zstd-jni:v1.3.3-3**. However ,as shown in the following dependency graph. **com.github.luben:zstd-jni:v1.3.3-3** sufferes from the vulnerability which the C library **zstd(version:1.3.3)** exposed: [CVE-2021-24031](https://nvd.nist.gov/vuln/detail/CVE-2021-24031),[CVE-2019-11922](https://nvd.nist.gov/vuln/detail/CVE-2019-11922).
### Dependency Graph between Java and Shared Libraries
![image (12)](https://user-images.githubusercontent.com/103260963/163176274-0a20322b-2935-4892-abec-7f543ede742b.png)
### Suggested Vulnerability Patch Versions
**com.github.luben:zstd-jni:v1.4.9-1** (**>=v1.4.9-1**) has upgraded this vulnerable C library `zstd` to the patch version **1.4.9**.

Java build tools cannot report vulnerable C libraries, which may induce potential security issues to many downstream Java projects. Could you please upgrade this vulnerable dependency?

Thanks for your help~
Best regards,
Helen Parr