### PR TITLE
Fixed a bug where Array columns were inconsistent in Expand.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/MaxLengthBasedArrayColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/MaxLengthBasedArrayColumnBinaryMaker.java
@@ -238,12 +238,11 @@ public class MaxLengthBasedArrayColumnBinaryMaker implements IColumnBinaryMaker 
     int loadOffset = 0;
     int childLength = 0;
     int rowGourpCount = 0;
+    int startArrayOffset = 0;
     List<Integer> childRepetitions = new ArrayList<>();
     for (int i = 0; i < columnBinary.repetitions.length; i++) {
       if (columnBinary.repetitions[i] == 0) {
-        if (i >= columnBinary.rowCount || isNullArray[i]) {
-          childRepetitions.add(0);
-        } else {
+        if (i < columnBinary.rowCount && ! isNullArray[i]) {
           for (int j = 0; j < lengthArray[i]; j++) {
             childRepetitions.add(0);
           }
@@ -252,12 +251,13 @@ public class MaxLengthBasedArrayColumnBinaryMaker implements IColumnBinaryMaker 
       }
       if (i >= columnBinary.rowCount || isNullArray[i]) {
         loader.setNullAndRepetitions(loadOffset, columnBinary.repetitions[i], rowGourpCount);
-        // NOTE: child does not inherit parent's repetitions.
-        childLength++;
-        childRepetitions.add(1);
       } else {
         loader.setRowGourpIndexAndRepetitions(
-            loadOffset, columnBinary.repetitions[i], rowGourpCount, startArray[i], lengthArray[i]);
+            loadOffset,
+            columnBinary.repetitions[i],
+            rowGourpCount,
+            startArrayOffset, lengthArray[i] );
+        startArrayOffset += lengthArray[i];
         // NOTE: child does not inherit parent's repetitions.
         childLength += lengthArray[i];
         for (int j = 0; j < lengthArray[i]; j++) {


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Fixed a bug where Array columns were inconsistent in Expand.
I think this is a fatal bug because it does not allow data to be acquired properly.

### How did you do the test? (Not required for updating documents)
Fixed unit tests and added patterns.

I confirmed that the unit test did not pass with the code before modification.
_[ERROR] Failures:
[ERROR]   TestArrayColumn.T_load_withAllIndexWithNull:357 expected: <4> but was: <7>
[ERROR]   TestArrayColumn.T_load_withOddNumberIndexAndExpand:629->checkExpandArray:224 expected: <dd> but was: <aa>
[ERROR]   TestArrayColumn.T_load_withOddNumberIndex:469->checkExpandArray:224 expected: <dd> but was: <aa>
[ERROR]   TestArrayColumn.T_load_withOutOfBoundsIndexAndExpand:595 expected: <13> but was: <14>
[ERROR]   TestArrayColumn.T_load_withOutOfBoundsIndex:435 expected: <13> but was: <14>
[ERROR] Errors:
[ERROR]   TestArrayColumn.T_load_withLast2IndexAndExpand:577->checkExpandArray:224 NullPointer
[ERROR]   TestArrayColumn.T_load_withLast2Index:417->checkExpandArray:224 NullPointer_