### PR TITLE
Revert to 2.0.6 because failed to upload to maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>jp.co.yahoo.yosegi</groupId>
   <artifactId>yosegi</artifactId>
-  <version>2.0.7-SNAPSHOT</version>
+  <version>2.0.6-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Yosegi</name>
   <description>Yosegi package.</description>


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
I reverted the library to 2.0.6 because it failed to upload to maven central.

### How did you do the test? (Not required for updating documents)
