### PR TITLE
Fixed an exception when a column specified in Flatten is of UNION type.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/spread/flatten/FlattenColumn.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/flatten/FlattenColumn.java
@@ -67,7 +67,8 @@ public class FlattenColumn {
           currentColumnBinary = newCurrent;
           currentColumnBinaryList = newColumnBinaryList;
         }
-        if ( currentColumnBinary.columnType != ColumnType.SPREAD ) {
+        if ( currentColumnBinary == null
+            || currentColumnBinary.columnType != ColumnType.SPREAD ) {
           return null;
         }
         currentColumnBinary =


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

There is insufficient null exception handling when the column specified in Flatten is of UNION type and does not contain a SPREAD type as a child.
Processing will not be possible if this correction is not made.

### How did you do the test? (Not required for updating documents)

Improvements were confirmed through unit testing.
