### PR TITLE
Fixed nesting check for Array child types.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/message/objects/JsonNodeToPrimitiveObject.java
+++ b/src/main/java/jp/co/yahoo/yosegi/message/objects/JsonNodeToPrimitiveObject.java
@@ -62,7 +62,7 @@ public class JsonNodeToPrimitiveObject {
     } else if ( jsonNode instanceof MissingNode ) {
       return NullObj.getInstance();
     } else {
-      return new StringObj( jsonNode.toString() );
+      return NullObj.getInstance();
     }
   }
 

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrayColumn.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/ArrayColumn.java
@@ -97,9 +97,8 @@ public class ArrayColumn implements IColumn {
       }
     } else {
       IParser parser = (IParser)obj;
-      boolean hasParser = parser.hasParser(0);
       for ( int i = 0 ; i < parser.size() ; i++ ) {
-        if ( hasParser ) {
+        if (  parser.hasParser(i) ) {
           totalBytes += spread.addRow( CHILD_COLUMN_NAME , parser.getParser(i) );
         } else {
           totalBytes += spread.addRow( CHILD_COLUMN_NAME , parser.get(i) );

--- a/src/test/java/jp/co/yahoo/yosegi/spread/expand/TestExpandNode.java
+++ b/src/test/java/jp/co/yahoo/yosegi/spread/expand/TestExpandNode.java
@@ -394,7 +394,16 @@ public class TestExpandNode {
     assertNotNull( findColumnBinaryFromColumnName( "col2" , binaryList ));
     ColumnBinary col2 = findColumnBinaryFromColumnName( "col2" , binaryList );
     ColumnBinary col2_2 = findColumnBinaryFromColumnName( "col2-2" , col2.columnBinaryList );
-    ColumnBinary col2_2_inner = col2_2.columnBinaryList.get(0);
+    ColumnBinary col2_2_inner = null;
+    for ( ColumnBinary c : col2_2.columnBinaryList ) {
+      if ( c.columnType == ColumnType.UNION ) {
+        for ( ColumnBinary c2 : c.columnBinaryList ) {
+          if ( c2.columnType == ColumnType.SPREAD ) {
+            col2_2_inner = c2;
+          }
+        }
+      }
+    }
     assertNotNull(findColumnBinaryFromColumnName("col2-2-1",col2_2_inner.columnBinaryList));
     assertNotNull(findColumnBinaryFromColumnName("col2-2-2",col2_2_inner.columnBinaryList));
     assertNotNull( findColumnBinaryFromColumnName( "ex_col3" , binaryList ));


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

In the current implementation, nesting is determined by the first element of an Array. Therefore, if the first element is a Primitive type or null and the next element is a nested type, it will be processed as a Primitive type, and will ultimately become null.
We will change the implementation so that the nesting type is determined for all elements and it assumes that the children of the Array are Unions.

### How did you do the test? (Not required for updating documents)

Added unit tests.
