### PR TITLE
Fixed a bug where children were not loaded when expanding.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/MaxLengthBasedArrayColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/MaxLengthBasedArrayColumnBinaryMaker.java
@@ -209,6 +209,9 @@ public class MaxLengthBasedArrayColumnBinaryMaker implements IColumnBinaryMaker 
           nullOffset += columnBinary.repetitions[i];
         }
       }
+      loader.loadChild(
+          UnsupportedColumnBinaryMaker.createUnsupportedColumnBinary( "child" , nullOffset ),
+          nullOffset);
       return;
     }
 


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
loadChild() was not called if the repetition start was greater than ColumnSize.
In this case, the processing would be different on the reading side, which could lead to unintended results.

### How did you do the test? (Not required for updating documents)
Added a unit test to ensure that loadChild() is called.