### PR TITLE
Change to allow setting to not read columns.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/block/EncryptionSupportedBlockReader.java
+++ b/src/main/java/jp/co/yahoo/yosegi/block/EncryptionSupportedBlockReader.java
@@ -127,7 +127,8 @@ public class EncryptionSupportedBlockReader implements IBlockReader {
         currentColumnNameNode = columnNameNode;
       }
     }
-    if ( columnFilterNode.isChildEmpty() ) {
+    if ( config.get( YosegiConfiguration.PROP_READ_COLUMN_NAME ) == null 
+        && columnFilterNode.isChildEmpty() ) {
       columnFilterNode.setNeedAllChild( true );
     } else {
       List<String[]> expandNeedColumnList = expandFunction.getExpandColumnName();

--- a/src/main/java/jp/co/yahoo/yosegi/block/PushdownSupportedBlockReader.java
+++ b/src/main/java/jp/co/yahoo/yosegi/block/PushdownSupportedBlockReader.java
@@ -110,7 +110,8 @@ public class PushdownSupportedBlockReader implements IBlockReader {
         currentColumnNameNode = columnNameNode;
       }
     }
-    if ( columnFilterNode.isChildEmpty() ) {
+    if ( config.get( "spread.reader.read.column.names" ) == null
+        && columnFilterNode.isChildEmpty() ) {
       columnFilterNode.setNeedAllChild( true );
     } else {
       List<String[]> expandNeedColumnList = expandFunction.getExpandColumnName();


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

Projection pushdown used to read everything if it wasn't set or if the target column didn't exist. 
There are cases where the request from the query engine is explicitly empty. 
Therefore, it will be changed so that nothing is read if it is set.

### How did you do the test? (Not required for updating documents)
