### PR TITLE
Added the ability to get child index from column name.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/IColumn.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/IColumn.java
@@ -66,6 +66,10 @@ public interface IColumn {
 
   IField getSchema( final String schemaName ) throws IOException;
 
+  default int getChildColumnIndex( final String columnName ) {
+    throw new UnsupportedOperationException( "This method only supports spread columns." );
+  }
+
   default boolean isExpandColumn() {
     return false;
   }

--- a/src/main/java/jp/co/yahoo/yosegi/spread/column/SpreadColumn.java
+++ b/src/main/java/jp/co/yahoo/yosegi/spread/column/SpreadColumn.java
@@ -175,6 +175,11 @@ public class SpreadColumn implements IColumn {
   }
 
   @Override
+  public int getChildColumnIndex( final String columnName ) {
+    return spread.getColumnIndex( columnName );
+  }
+
+  @Override
   public String toString() {
     StringBuffer result = new StringBuffer();
     result.append( String.format( "Column name : %s\n" , getColumnName() ) );


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

When exchanging data, there needs to be a function to reverse-look up the index from the key name of the child column.
Without this implementation, certain data exchange processes cannot be realized.

### How did you do the test? (Not required for updating documents)
