### PR TITLE
Fix issue where YosegiReader metrics were smaller than expected

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/block/PushdownSupportedBlockReader.java
+++ b/src/main/java/jp/co/yahoo/yosegi/block/PushdownSupportedBlockReader.java
@@ -142,10 +142,11 @@ public class PushdownSupportedBlockReader implements IBlockReader {
   public void setStream( final InputStream in , final int blockSize ) throws IOException {
     clear();
     byte[] compressorClassLengthBytes = new byte[Integer.BYTES];
-    InputStreamUtils.read( in , compressorClassLengthBytes , 0 , Integer.BYTES );
+    readBytes += InputStreamUtils.read( in , compressorClassLengthBytes , 0 , Integer.BYTES );
     int compressorClassLength = ByteBuffer.wrap( compressorClassLengthBytes ).getInt();
     byte[] compressorClassBytes = new byte[ compressorClassLength ];
-    InputStreamUtils.read( in , compressorClassBytes , 0 , compressorClassBytes.length );
+    readBytes +=
+            InputStreamUtils.read( in , compressorClassBytes , 0 , compressorClassBytes.length );
     compressor = FindCompressor.get(
         CompressorNameShortCut.getClassName( new String( compressorClassBytes , "UTF-8" ) ) );
 

--- a/src/main/java/jp/co/yahoo/yosegi/reader/YosegiReader.java
+++ b/src/main/java/jp/co/yahoo/yosegi/reader/YosegiReader.java
@@ -54,6 +54,11 @@ public class YosegiReader implements AutoCloseable {
   private int blockSize;
   private long inReadOffset;
 
+  private int blockReadCount;
+  private int blockCount;
+  private SummaryStats readStats = new SummaryStats();
+  private long readBytes;
+
   private class FileHeaderMeta {
     public final int blockSize;
     public final int headerSize;
@@ -78,24 +83,24 @@ public class YosegiReader implements AutoCloseable {
 
   private FileHeaderMeta readFileHeader( final InputStream in ) throws IOException {
     byte[] magic = new byte[MAGIC.length];
-    InputStreamUtils.read( in , magic , 0 , MAGIC.length );
+    readBytes += InputStreamUtils.read( in , magic , 0 , MAGIC.length );
 
     if ( ! Arrays.equals( magic , MAGIC) ) {
       throw new IOException( "Invalid binary." );
     }
 
     byte[] blockSizeBytes = new byte[Integer.BYTES];
-    InputStreamUtils.read( in , blockSizeBytes , 0 , Integer.BYTES );
+    readBytes += InputStreamUtils.read( in , blockSizeBytes , 0 , Integer.BYTES );
     ByteBuffer wrapBuffer = ByteBuffer.wrap( blockSizeBytes );
     final int readBlockSize = wrapBuffer.getInt( 0 );
 
     byte[] blockClassLength = new byte[Integer.BYTES];
     ByteBuffer wrapLengthBuffer = ByteBuffer.wrap( blockClassLength );
-    InputStreamUtils.read( in , blockClassLength , 0 , Integer.BYTES );
+    readBytes += InputStreamUtils.read( in , blockClassLength , 0 , Integer.BYTES );
     int classNameSize = wrapLengthBuffer.getInt( 0 );
 
     byte[] blockClass = new byte[classNameSize];
-    InputStreamUtils.read( in , blockClass , 0 , classNameSize );
+    readBytes += InputStreamUtils.read( in , blockClass , 0 , classNameSize );
     ByteBuffer classNameBuffer = ByteBuffer.wrap( blockClass );
     CharBuffer viewCharBuffer = classNameBuffer.asCharBuffer();
     char[] classNameChars = new char[ classNameSize / Character.BYTES ];
@@ -175,9 +180,15 @@ public class YosegiReader implements AutoCloseable {
       if ( readTargetList.isEmpty() ) {
         return false;
       }
+      // blockReadCount is incremented in IBlockReader.nextRaw method
+      blockReadCount += currentBlockReader.getBlockReadCount();
       ReadBlockOffset readOffset = readTargetList.remove(0);
       inReadOffset += InputStreamUtils.skip( in , readOffset.start - inReadOffset );
       currentBlockReader.setStream( in , readOffset.length );
+      blockCount += currentBlockReader.getBlockCount();
+      readBytes += currentBlockReader.getReadBytes();
+      // IBlockReader.getReadStats method returns an empty result
+      readStats.merge( currentBlockReader.getReadStats() );
       inReadOffset += readOffset.length;
     }
     return true;
@@ -220,12 +231,19 @@ public class YosegiReader implements AutoCloseable {
     return localSpredPushdown( currentBlockReader.nextRaw() );
   }
 
+  /**
+   * Get total block read count.
+   */
   public int getBlockReadCount() {
-    return currentBlockReader.getBlockReadCount();
+    // blockReadCount is incremented in IBlockReader.nextRaw method
+    if ( currentBlockReader == null ) {
+      return blockReadCount;
+    }
+    return blockReadCount + currentBlockReader.getBlockReadCount();
   }
 
   public int getBlockCount() {
-    return currentBlockReader.getBlockCount();
+    return blockCount;
   }
 
   public long getReadPos() {
@@ -233,15 +251,17 @@ public class YosegiReader implements AutoCloseable {
   }
 
   public Integer getCurrentSpreadSize() {
+    // currentBlockReader can be null
     return currentBlockReader.getCurrentSpreadSize();
   }
 
   public SummaryStats getReadStats() {
-    return currentBlockReader.getReadStats();
+    // IBlockReader.getReadStats method returns an empty result
+    return readStats;
   }
 
   public long getReadBytes() {
-    return currentBlockReader.getReadBytes();
+    return readBytes;
   }
 
   /**
@@ -253,6 +273,10 @@ public class YosegiReader implements AutoCloseable {
       in = null;
     }
     inReadOffset = 0;
+    blockReadCount = 0;
+    blockCount = 0;
+    readStats.clear();
+    readBytes = 0;
     readTargetList.clear();
     currentBlockReader.close();
   }

--- a/src/test/java/jp/co/yahoo/yosegi/reader/TestYosegiReader.java
+++ b/src/test/java/jp/co/yahoo/yosegi/reader/TestYosegiReader.java
@@ -104,40 +104,93 @@ public class TestYosegiReader {
 
   @Test
   public void T_read_1() throws IOException {
+    // File Header: 118
+    // Block-1: Meta: 71, Spread: 208, Offset: 10
+    // Block-2: Meta: 71, Spread: 208, Offset: 10
+    // Block-3: Meta: 72, Spread: 132, Offset: 5
     byte[] blocks = createTestBinary();
     ByteArrayInputStream in = new ByteArrayInputStream( blocks );
     YosegiReader reader = new YosegiReader();
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 0, reader.getReadBytes() );
+
     reader.setNewStream( in , blocks.length , new Configuration() );
+    // File Header size is 118B
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 407, reader.getReadBytes() );
     assertEquals( reader.hasNext() , true );
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 407, reader.getReadBytes() );
 
     // Block-1 Spread-1
     List<ColumnBinary> raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 1 );
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 407, reader.getReadBytes() );
+    assertEquals( reader.hasNext() , true );
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 407, reader.getReadBytes() );
     // Block-1 Spread-2
     raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 1 );
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 2, reader.getBlockReadCount() );
+    assertEquals( 407, reader.getReadBytes() );
+    assertEquals( reader.hasNext() , true );
+    assertEquals( 4, reader.getBlockCount() );
+    assertEquals( 2, reader.getBlockReadCount() );
+    assertEquals( 696, reader.getReadBytes() );
 
     // Block-2 Spread-1
     raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 1 );
+    assertEquals( 4, reader.getBlockCount() );
+    assertEquals( 3, reader.getBlockReadCount() );
+    assertEquals( 696, reader.getReadBytes() );
+    assertEquals( reader.hasNext() , true );
+    assertEquals( 4, reader.getBlockCount() );
+    assertEquals( 3, reader.getBlockReadCount() );
+    assertEquals( 696, reader.getReadBytes() );
     // Block-2 Spread-2
     raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 1 );
+    assertEquals( 4, reader.getBlockCount() );
+    assertEquals( 4, reader.getBlockReadCount() );
+    assertEquals( 696, reader.getReadBytes() );
+    assertEquals( reader.hasNext() , true );
+    assertEquals( 5, reader.getBlockCount() );
+    assertEquals( 4, reader.getBlockReadCount() );
+    assertEquals( 905, reader.getReadBytes() );
 
     // Block-3 Spread-1
     raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 1 );
+    assertEquals( 5, reader.getBlockCount() );
+    assertEquals( 5, reader.getBlockReadCount() );
+    assertEquals( 905, reader.getReadBytes() );
 
     assertEquals( reader.hasNext() , false );
+    assertEquals( 5, reader.getBlockCount() );
+    assertEquals( 5, reader.getBlockReadCount() );
+    assertEquals( 905, reader.getReadBytes() );
   }
 
   @Test
   public void T_EmptyPushdown_1() throws IOException {
+    // File Header: 118
+    // Block-1: Meta: 71, Spread: 208, Offset: 10
+    // Block-2: Meta: 71, Spread: 208, Offset: 10
+    // Block-3: Meta: 72, Spread: 132, Offset: 5
     byte[] blocks = createTestBinary();
     ByteArrayInputStream in = new ByteArrayInputStream( blocks );
     YosegiReader reader = new YosegiReader();
@@ -149,18 +202,41 @@ public class TestYosegiReader {
     Configuration readerConfig = new Configuration();
     // Skip Block-1, Block-2
     reader.setBlockSkipIndex( index );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 0, reader.getReadBytes() );
+
     reader.setNewStream( in , blocks.length , readerConfig );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    // 118 + 71 + 71 + (72 + 132 + 5) = 469
+    assertEquals( 469, reader.getReadBytes() );
+
     assertEquals( reader.hasNext() , true );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 469, reader.getReadBytes() );
 
     // Block-3 Spread-1
     List<ColumnBinary> raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 1 );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 469, reader.getReadBytes() );
+
     assertEquals( reader.hasNext() , false );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 469, reader.getReadBytes() );
   }
 
   @Test
   public void T_EmptyPushdown_2() throws IOException {
+    // File Header: 118
+    // Block-1: Meta: 71, Spread: 208, Offset: 10
+    // Block-2: Meta: 71, Spread: 208, Offset: 10
+    // Block-3: Meta: 72, Spread: 132, Offset: 5
     byte[] blocks = createTestBinary();
     ByteArrayInputStream in = new ByteArrayInputStream( blocks );
     YosegiReader reader = new YosegiReader();
@@ -173,18 +249,40 @@ public class TestYosegiReader {
     readerConfig.set( "spread.reader.read.column.names" , "[[\"column\"]]" );
     // Skip Block-1, Block-2
     reader.setBlockSkipIndex( index );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 0, reader.getReadBytes() );
+
     reader.setNewStream( in , blocks.length , readerConfig );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    // 118 + 71 + 71 + (72 + 132) = 464
+    assertEquals( 464, reader.getReadBytes() );
+
     assertEquals( reader.hasNext() , true );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 464, reader.getReadBytes() );
     // Block-3 Spread-1
     List<ColumnBinary> raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
-    assertEquals( reader.getBlockReadCount() , 1 );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 464, reader.getReadBytes() );
     assertEquals( raw.size() , 0 );
+
     assertEquals( reader.hasNext() , false );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 464, reader.getReadBytes() );
   }
 
   @Test
   public void T_EmptyPushdown_3() throws IOException {
+    // File Header: 118
+    // Block-1: Meta: 71, Spread: 208, Offset: 10
+    // Block-2: Meta: 71, Spread: 208, Offset: 10
+    // Block-3: Meta: 72, Spread: 132, Offset: 5
     byte[] blocks = createTestBinary();
     ByteArrayInputStream in = new ByteArrayInputStream( blocks );
     YosegiReader reader = new YosegiReader();
@@ -196,37 +294,80 @@ public class TestYosegiReader {
     Configuration readerConfig = new Configuration();
     readerConfig.set( "spread.reader.read.column.names" , "[[\"column2\"]]" );
     reader.setBlockSkipIndex( index );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 0, reader.getReadBytes() );
+
     // Skip Block-3
     reader.setNewStream( in , blocks.length , readerConfig );
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    // 118 + (71 + 208) = 397
+    assertEquals( 397, reader.getReadBytes() );
+
     assertEquals( reader.hasNext() , true );
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 397, reader.getReadBytes() );
 
     // Block-1 Spread-1
     List<ColumnBinary> raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 0 );
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 397, reader.getReadBytes() );
     assertEquals( reader.hasNext() , true );
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 397, reader.getReadBytes() );
 
     // Block-1 Spread-2
     raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 0 );
+    assertEquals( 2, reader.getBlockCount() );
+    assertEquals( 2, reader.getBlockReadCount() );
+    assertEquals( 397, reader.getReadBytes() );
     assertEquals( reader.hasNext() , true );
+    assertEquals( 4, reader.getBlockCount() );
+    assertEquals( 2, reader.getBlockReadCount() );
+    // 118 + (71 + 208) + (71 + 208) = 676
+    assertEquals( 676, reader.getReadBytes() );
 
     // Block-2 Spread-1
     raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 0 );
+    assertEquals( 4, reader.getBlockCount() );
+    assertEquals( 3, reader.getBlockReadCount() );
+    assertEquals( 676, reader.getReadBytes() );
     assertEquals( reader.hasNext() , true );
+    assertEquals( 4, reader.getBlockCount() );
+    assertEquals( 3, reader.getBlockReadCount() );
+    assertEquals( 676, reader.getReadBytes() );
 
     // Block-2 Spread-2
     raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 0 );
+    assertEquals( 4, reader.getBlockCount() );
+    assertEquals( 4, reader.getBlockReadCount() );
+    assertEquals( 676, reader.getReadBytes() );
+
     assertEquals( reader.hasNext() , false );
+    assertEquals( 4, reader.getBlockCount() );
+    assertEquals( 4, reader.getBlockReadCount() );
+    // 118 + (71 + 208) + (71 + 208) + 72 = 748
+    assertEquals( 748, reader.getReadBytes() );
   }
 
   @Test
   public void T_EmptyPushdownAndBlockRead_1() throws IOException {
+    // File Header: 118
+    // Block-1: Meta: 71, Spread: 208, Offset: 10
+    // Block-2: Meta: 71, Spread: 208, Offset: 10
+    // Block-3: Meta: 72, Spread: 132, Offset: 5
     byte[] blocks = createTestBinary();
     ByteArrayInputStream in = new ByteArrayInputStream( blocks );
     YosegiReader reader = new YosegiReader();
@@ -238,13 +379,27 @@ public class TestYosegiReader {
     Configuration readerConfig = new Configuration();
     // Skip Block-1, Block-2
     reader.setBlockSkipIndex( index );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 0, reader.getReadBytes() );
     // Read Block-1, Block-2
     reader.setNewStream( in , blocks.length , readerConfig , 0 , blockSize * 2 );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    // 118 + 71 + 71 = 260
+    assertEquals( 260, reader.getReadBytes() );
     assertEquals( reader.hasNext() , false );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 260, reader.getReadBytes() );
   }
 
   @Test
   public void T_EmptyPushdownAndBlockRead_2() throws IOException {
+    // File Header: 118
+    // Block-1: Meta: 71, Spread: 208, Offset: 10
+    // Block-2: Meta: 71, Spread: 208, Offset: 10
+    // Block-3: Meta: 72, Spread: 132, Offset: 5
     byte[] blocks = createTestBinary();
     ByteArrayInputStream in = new ByteArrayInputStream( blocks );
     YosegiReader reader = new YosegiReader();
@@ -256,13 +411,27 @@ public class TestYosegiReader {
     Configuration readerConfig = new Configuration();
     // Skip Block-1, Block-2
     reader.setBlockSkipIndex( index );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 0, reader.getReadBytes() );
     // Read Block-2
     reader.setNewStream( in , blocks.length , readerConfig , blockSize , blockSize );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    // 118 + 71 = 189
+    assertEquals( 189, reader.getReadBytes() );
     assertEquals( reader.hasNext() , false );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 189, reader.getReadBytes() );
   }
 
   @Test
   public void T_EmptyPushdownAndBlockRead_3() throws IOException {
+    // File Header: 118
+    // Block-1: Meta: 71, Spread: 208, Offset: 10
+    // Block-2: Meta: 71, Spread: 208, Offset: 10
+    // Block-3: Meta: 72, Spread: 132, Offset: 5
     byte[] blocks = createTestBinary();
     ByteArrayInputStream in = new ByteArrayInputStream( blocks );
     YosegiReader reader = new YosegiReader();
@@ -274,20 +443,40 @@ public class TestYosegiReader {
     Configuration readerConfig = new Configuration();
     // Skip Block-1, Block-2
     reader.setBlockSkipIndex( index );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 0, reader.getReadBytes() );
     // Read Block-3
     reader.setNewStream( in , blocks.length , readerConfig , blockSize * 2 , blockSize );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    // 118 + (72 + 132 + 5) = 327
+    assertEquals( 327, reader.getReadBytes() );
 
     assertEquals( reader.hasNext() , true );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 327, reader.getReadBytes() );
     // Block-3 Spread-1
     List<ColumnBinary> raw = reader.nextRaw();
     assertEquals( reader.getCurrentSpreadSize().intValue() , 4 );
     assertEquals( raw.size() , 1 );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 327, reader.getReadBytes() );
 
     assertEquals( reader.hasNext() , false );
+    assertEquals( 1, reader.getBlockCount() );
+    assertEquals( 1, reader.getBlockReadCount() );
+    assertEquals( 327, reader.getReadBytes() );
   }
 
   @Test
   public void T_ReadWithoutBlock_1() throws IOException {
+    // File Header: 118
+    // Block-1: Meta: 71, Spread: 208, Offset: 10
+    // Block-2: Meta: 71, Spread: 208, Offset: 10
+    // Block-3: Meta: 72, Spread: 132, Offset: 5
     byte[] blocks = createTestBinary();
     ByteArrayInputStream in = new ByteArrayInputStream( blocks );
     YosegiReader reader = new YosegiReader();
@@ -298,9 +487,19 @@ public class TestYosegiReader {
     );
     Configuration readerConfig = new Configuration();
     reader.setBlockSkipIndex( index );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 0, reader.getReadBytes() );
     // There is no block to read.
     reader.setNewStream( in , blocks.length , readerConfig , 1024 * 256 , 1024 * 256 );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    // 118
+    assertEquals( 118, reader.getReadBytes() );
     assertEquals( reader.hasNext() , false );
+    assertEquals( 0, reader.getBlockCount() );
+    assertEquals( 0, reader.getBlockReadCount() );
+    assertEquals( 118, reader.getReadBytes() );
   }
 
 }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
I changed YosegiReader to return the cumulative metrics of all blocks read so far instead of only the metrics of the currently read block when reading multiple blocks.

### How did you do the test? (Not required for updating documents)
I tested in TestYosegiReader.