### PR TITLE
chore: bump central-publishing-maven-plugin to 0.10.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.7.0</version>
+        <version>0.10.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

This update is for periodically verifying the build and Maven Central publishing workflow.

- Bump central-publishing-maven-plugin from 0.7.0 to 0.10.0

### How did you do the test? (Not required for updating documents)
